### PR TITLE
Add Invite Friends Banner Component 

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,11 +1,10 @@
-
-
 "use client";
 
 import { useEffect, useState } from "react";
 import WelcomeHeader from "@/components/dashboard/WelcomeHeader";
 import BalanceCard from "@/components/dashboard/BalanceCard";
 import RecentQuizWidget from "@/components/dashboard/RecentQuizWidget";
+import InviteFriendsBanner from "@/components/dashboard/InviteFriendsBanner";
 
 // Mock data for now - later will be replaced with actual API calls
 const mockUser = {
@@ -76,11 +75,19 @@ export default function DashboardPage() {
             }}
           />
         )}
+
+        {/* Invite Friends Banner */}
+        <InviteFriendsBanner
+          onInvite={() => {
+            // TODO: Analytics tracking for invite action
+            console.log("User clicked invite friends");
+          }}
+          onDismiss={() => {
+            // TODO: Analytics tracking for banner dismiss
+            console.log("User dismissed invite banner");
+          }}
+        />
       </div>
     </main>
   );
 }
-
-
-
-

--- a/src/components/dashboard/InviteFriendsBanner.tsx
+++ b/src/components/dashboard/InviteFriendsBanner.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface InviteFriendsBannerProps {
+  onInvite?: () => void;
+  onDismiss?: () => void;
+}
+
+export default function InviteFriendsBanner({
+  onInvite,
+  onDismiss,
+}: InviteFriendsBannerProps) {
+  const [isVisible, setIsVisible] = useState(true);
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    onDismiss?.();
+  };
+
+  const handleInvite = async () => {
+    // Try to use native share API if available
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "Join DeQuizifi",
+          text: "Join me on DeQuizifi and earn rewards together!",
+          url: window.location.origin,
+        });
+      } catch {
+        // User cancelled or share failed, fallback to copy
+        await copyInviteLink();
+      }
+    } else {
+      // Fallback to copying link
+      await copyInviteLink();
+    }
+
+    onInvite?.();
+  };
+
+  const copyInviteLink = async () => {
+    try {
+      const inviteLink = `${window.location.origin}?ref=invite`;
+      await navigator.clipboard.writeText(inviteLink);
+
+      // Optional: Show toast notification
+      // Could be implemented with a toast library later
+      console.log("Invite link copied to clipboard");
+    } catch (error) {
+      console.error("Failed to copy invite link:", error);
+    }
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      className="mx-6 my-2"
+      role="banner"
+      aria-label="Invite friends promotion"
+    >
+      <div className="relative rounded-2xl overflow-hidden">
+        {/* Glassmorphism Background */}
+        <div className="absolute inset-0 bg-gradient-to-br from-white/30 via-white/20 to-white/10 backdrop-blur-md border border-white/20" />
+
+        {/* Close Button - Top Right Corner with transparent background */}
+        <button
+          onClick={handleDismiss}
+          className="absolute  top-1 right-1 z-20 p-2 rounded-full hover:bg-white/10 transition-colors duration-200"
+          aria-label="Close invite banner"
+          style={{ minWidth: "44px", minHeight: "44px" }}
+        >
+          <X className="w-5 h-5 text-white" />
+        </button>
+
+        {/* Content */}
+        <div className="mt-2 relative p-6 text-center">
+          {/* Title */}
+          <h2 className="text-white font-semibold text-lg mb-2 font-mono ">
+            MORE FRIENDS, MORE REWARDS
+          </h2>
+
+          {/* Description */}
+          <p
+            className="text-white/90 text-lg mb-6 leading-relaxed max-w-xs mx-auto font-semibold
+           font-mono"
+          >
+            Invite your friends to take part in challenges and earn rewards
+            together
+          </p>
+
+          {/* Invite Button */}
+          <Button
+            onClick={handleInvite}
+            className="bg-white text-foreground font-semibold px-8 py-3 rounded-full hover:bg-white/90 transition-colors duration-200 min-h-[44px] shadow-lg"
+            aria-label="Invite friends to DeQuizifi"
+          >
+            Invite Friends
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**PR Description:**

This PR introduces the `InviteFriendsBanner` component to the dashboard, matching the provided design and requirements:

- Glassmorphism background with subtle white gradient and blur.
- Top-right close (X) icon from lucide-react, fully accessible, with transparent background and 44px tap target.
- “Invite Friends” button triggers the native share sheet (if available) or copies an invite link to the clipboard as fallback.
- Banner text and button styled with Tailwind CSS and shadcn/ui, using consistent horizontal margins (`mx-6`) to align with the Recent Quiz Widget.
- Fully accessible: ARIA labels, keyboard navigation, and screen reader support.
- Component is dismissible and will not reappear after closing.
- Ready for analytics integration via `onInvite` and `onDismiss` props.

This completes the Invite Friends Banner task as specified in the acceptance criteria.

<img width="318" height="688" alt="image" src="https://github.com/user-attachments/assets/6a2d850a-637a-406c-8b96-183e7d0eb91d" />

