### PR TITLE
feat: initial leaderboard page setup with welcomeHeader and balanceCard

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React from "react";
+import WelcomeHeader from "@/components/dashboard/WelcomeHeader";
+import BalanceCard from "@/components/dashboard/BalanceCard";
+
+export default function LeaderboardPage() {
+  return (
+    <div className="min-h-screen relative">
+      {/* Background Image */}
+      <div
+        className="absolute inset-0 w-full h-full bg-cover bg-center bg-no-repeat"
+        style={{
+          backgroundImage: "url('/images/dashboard.svg')",
+        }}
+      />
+
+      {/* Content Overlay */}
+      <div className="relative z-10 p-6">
+        {/* Header Section with Welcome and Balance */}
+        <div className="flex items-start justify-between mb-8">
+          <WelcomeHeader name="Arion Loveless" />
+          <BalanceCard amount={602} />
+        </div>
+
+        {/* Leaderboard Content Area */}
+        <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 min-h-[600px]">
+          <h2 className="text-white text-2xl font-bold mb-6">Leaderboard</h2>
+
+          {/* Placeholder for leaderboard content */}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/WelcomeHeader.tsx
+++ b/src/components/dashboard/WelcomeHeader.tsx
@@ -10,9 +10,9 @@ export default function WelcomeHeader({ name = "User" }: WelcomeHeaderProps) {
   return (
     <div className="flex-1">
       <div className="space-y-1">
-        <p className="text-white/90 font-bold font-mono ">Welcome</p>
+        <p className="text-white/90 font-bold">Welcome</p>
         <h1
-          className="text-white text-2xl font-mono font-bold"
+          className="text-white text-2xl font-bold"
           aria-label={`Welcome ${name}`}
         >
           {name}

--- a/src/components/dashboard/WelcomeHeader.tsx
+++ b/src/components/dashboard/WelcomeHeader.tsx
@@ -10,9 +10,9 @@ export default function WelcomeHeader({ name = "User" }: WelcomeHeaderProps) {
   return (
     <div className="flex-1">
       <div className="space-y-1">
-        <p className="text-white/90 font-bold ">Welcome</p>
+        <p className="text-white/90 font-bold font-mono ">Welcome</p>
         <h1
-          className="text-white text-2xl font-bold"
+          className="text-white text-2xl font-mono font-bold"
           aria-label={`Welcome ${name}`}
         >
           {name}


### PR DESCRIPTION
**PR Description:**  
This pull request addresses #20  introduces the initial setup for the Leaderboard page. Key features include:

- Added a new `/leaderboard` page with a visually appealing gradient background 
- Integrated `WelcomeHeader` and `BalanceCard` components in a responsive flex layout at the top of the page.
- Established a clean content area for future leaderboard features, following the design system.
- Ensured the structure is ready for upcoming enhancements such as ranking tabs, top 3 user highlights, and a scrollable user list.

<img width="422" height="839" alt="image" src="https://github.com/user-attachments/assets/00fb84e9-f578-4933-a66b-6f288e3f29a7" />
