### PR TITLE
feat: add ranking tabs and gradient panel with rounded top

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,10 +1,47 @@
 "use client";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import WelcomeHeader from "@/components/dashboard/WelcomeHeader";
 import BalanceCard from "@/components/dashboard/BalanceCard";
+import { cn } from "@/lib/utils";
 
 export default function LeaderboardPage() {
+  const [activeTab, setActiveTab] = useState<"week" | "allTime">("week");
+  const [timeRemaining, setTimeRemaining] = useState<string>("");
+
+  // Calculate time remaining in the week
+  useEffect(() => {
+    const updateRemainingTime = () => {
+      const now = new Date();
+      const dayOfWeek = now.getDay(); // 0 is Sunday, 6 is Saturday
+      const hoursInDay = now.getHours();
+      const minutesInHour = now.getMinutes();
+      const secondsInMinute = now.getSeconds();
+
+      // Calculate days until end of week (Sunday)
+      const daysRemaining = 7 - dayOfWeek;
+
+      // Calculate total hours, minutes, seconds remaining
+      const hoursRemaining = 24 - hoursInDay - 1;
+      const minutesRemaining = 60 - minutesInHour - 1;
+      const secondsRemaining = 60 - secondsInMinute;
+
+      setTimeRemaining(
+        `${daysRemaining}d ${hoursRemaining}h ${minutesRemaining}m ${secondsRemaining}s`
+      );
+    };
+
+    updateRemainingTime();
+    const timer = setInterval(updateRemainingTime, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  const handleTabChange = (tab: "week" | "allTime") => {
+    setActiveTab(tab);
+    // In a real implementation, here we would fetch the appropriate leaderboard data
+  };
+
   return (
     <div className="min-h-screen relative">
       {/* Background Image */}
@@ -24,10 +61,86 @@ export default function LeaderboardPage() {
         </div>
 
         {/* Leaderboard Content Area */}
-        <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 min-h-[600px]">
-          <h2 className="text-white text-2xl font-bold mb-6">Leaderboard</h2>
+        <div
+          className={cn(
+            // Full-bleed horizontally, rounded only on the top
+            "mx-[-1.5rem] rounded-t-3xl p-6 min-h-[600px] font-mono overflow-hidden"
+          )}
+          style={{
+            backgroundImage:
+              "linear-gradient(180deg, #FFFFFF 0%, #5F478F 55%, #272052 100%)",
+          }}
+        >
+          <h2 className="text-[#1b123d] text-2xl font-bold mb-6">
+            Leaderboard
+          </h2>
+
+          {/* Tabs for Ranking View */}
+          <div className="mb-6">
+            <div className="flex border-b border-black/10">
+              <button
+                className={cn(
+                  "pb-2 px-4 text-base transition-colors",
+                  // Active: dark purple text with solid underline
+                  activeTab === "week"
+                    ? "text-[#2B2356] font-semibold border-b-2 border-[#2B2356]"
+                    : "text-black/50 hover:text-black/70"
+                )}
+                onClick={() => handleTabChange("week")}
+                aria-label="View this week's leaderboard"
+              >
+                This week
+              </button>
+              <button
+                className={cn(
+                  "pb-2 px-4 text-base transition-colors",
+                  activeTab === "allTime"
+                    ? "text-[#2B2356] font-semibold border-b-2 border-[#2B2356]"
+                    : "text-black/50 hover:text-black/70"
+                )}
+                onClick={() => handleTabChange("allTime")}
+                aria-label="View all time leaderboard"
+              >
+                All time
+              </button>
+            </div>
+
+            {/* Time Remaining Display (Only shown for "This week" tab) */}
+            {activeTab === "week" && (
+              <div className="flex items-center mt-2 text-black/60 text-sm">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-4 w-4 mr-1"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <span aria-label="Time remaining in the week">
+                  {timeRemaining}
+                </span>
+              </div>
+            )}
+          </div>
 
           {/* Placeholder for leaderboard content */}
+          <div className="mt-4">
+            {activeTab === "week" ? (
+              <div className="text-black/70">
+                {/* Weekly leaderboard content will go here */}
+              </div>
+            ) : (
+              <div className="text-black/70">
+                {/* All-time leaderboard content will go here */}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/dashboard/WelcomeHeader.tsx
+++ b/src/components/dashboard/WelcomeHeader.tsx
@@ -12,7 +12,7 @@ export default function WelcomeHeader({ name = "User" }: WelcomeHeaderProps) {
       <div className="space-y-1">
         <p className="text-white/90 font-bold">Welcome</p>
         <h1
-          className="text-white text-2xl font-bold"
+          className="text-white text-2xl font-mono font-bold"
           aria-label={`Welcome ${name}`}
         >
           {name}

--- a/src/components/dashboard/WelcomeHeader.tsx
+++ b/src/components/dashboard/WelcomeHeader.tsx
@@ -12,7 +12,7 @@ export default function WelcomeHeader({ name = "User" }: WelcomeHeaderProps) {
       <div className="space-y-1">
         <p className="text-white/90 font-bold">Welcome</p>
         <h1
-          className="text-white text-2xl font-mono font-bold"
+          className="text-white text-2xl font-bold"
           aria-label={`Welcome ${name}`}
         >
           {name}


### PR DESCRIPTION
## PR Description:

This PR addresses #20 
- Add “This week” / “All time” tabs with active underline and color per design.
- Convert leaderboard container to top-rounded, full-bleed panel with white→purple gradient.
- Update heading/timer to dark text for contrast on light top of gradient.
- Keep placeholders for future content; data fetching to be added in next PRs.

<img width="422" height="837" alt="image" src="https://github.com/user-attachments/assets/3ef462ff-6c1a-47ef-aa36-ff2944e4a78e" />
