### PR TITLE
fix: hide navbar on login page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import BottomNavbar from "@/components/layout/BottomNavbar";
 import "./globals.css";
 import RainbowKitProviderWrapper from "@/providers/RainbowKitProviderWrapper";
+import ConditionalNavbar from "@/components/layout/ConditionalNavbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,14 +30,12 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <RainbowKitProviderWrapper>
-        <div className="max-h-screen flex flex-col">
-          {/* Main content area with bottom padding for navbar */}
-          <main className="flex-1">
-            {children}
-          </main>
-          {/* Bottom Navigation */}
-          <BottomNavbar />
-        </div>
+          <div className="max-h-screen flex flex-col">
+            {/* Main content area with bottom padding for navbar */}
+            <main className="flex-1">{children}</main>
+            {/* Conditional Bottom Navigation */}
+            <ConditionalNavbar />
+          </div>
         </RainbowKitProviderWrapper>
       </body>
     </html>

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function LoginLayout({ children }: { children: ReactNode }) {
+  return <div className="min-h-screen">{children}</div>;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,7 @@ import WalletLoginButton from "@/components/custom/common/WalletLoginButton";
 function page() {
   return (
     <div
-      className="min-h-screen bg-no-repeat bg-cover flex flex-col "
+      className="h-screen bg-no-repeat bg-cover flex flex-col "
       style={{ backgroundImage: "url('/images/login-bg.svg')" }}
     >
       <div className="container mx-auto my-80 text-white p-8">

--- a/src/components/layout/ConditionalNavbar.tsx
+++ b/src/components/layout/ConditionalNavbar.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import BottomNavbar from "./BottomNavbar";
+
+export default function ConditionalNavbar() {
+  const pathname = usePathname();
+
+  // Hide navbar on login page
+  if (pathname === "/login") {
+    return null;
+  }
+
+  return <BottomNavbar />;
+}


### PR DESCRIPTION
**PR Description:**  
This PR updates the global layout logic to ensure the `BottomNavbar` is not rendered on the `/login` page, while remaining visible on all other routes. The solution uses a dedicated `ConditionalNavbar` component with Next.js `usePathname()` to conditionally render the navbar based on the current route. This approach is scalable, maintainable, and works seamlessly with client-side navigation.

- Adds `ConditionalNavbar` component for route-based navbar visibility
- Updates `RootLayout` to use `ConditionalNavbar` instead of direct `BottomNavbar`
- Ensures login page remains fully responsive and centered without navbar space
- Follows idiomatic Next.js App Router patterns and best practices

This resolves the issue of the navbar appearing on the login page and improves overall layout maintainability.