### PR TITLE
feat: map trending quiz cards and add bottom padding to last card

### DIFF
--- a/src/components/dashboard/TrendingQuiz.tsx
+++ b/src/components/dashboard/TrendingQuiz.tsx
@@ -8,21 +8,32 @@ import {
 import Image from "next/image";
 
 export default function TrendingQuiz() {
+  const cards: { title: string; description: string; action: string }[] = [
+    { title: "DEX vs CEX", description: "20 questions", action: "1234" },
+    { title: "Unstable Coin", description: "20 questions", action: "1204" },
+    { title: "Layer 2 Trivia", description: "15 questions", action: "984" },
+    {
+      title: "Smart Contract Basics",
+      description: "10 questions",
+      action: "762",
+    },
+    { title: "Market Mechanics", description: "25 questions", action: "2041" },
+  ];
+
   return (
     <div className="border border-gray-200 bg-white rounded-t-xl p-4 shadow-sm">
       <h1 className="text-2xl font-semibold mx-2 my-2">Trending Quizzes</h1>
       {/* center the card list so each card can use mx-auto / max-w on small screens */}
       <div className="flex flex-col items-center">
-        <ReusableCard
-          title="DEX vs CEX"
-          description="20 questions"
-          action="1234"
-        />
-        <ReusableCard
-          title="Unstable Coin"
-          description="20 questions"
-          action="1204"
-        />
+        {cards.map((c, i) => (
+          <ReusableCard
+            key={`${c.title}-${c.action}-${i}`}
+            title={c.title}
+            description={c.description}
+            action={c.action}
+            isLast={i === cards.length - 1}
+          />
+        ))}
       </div>
     </div>
   );
@@ -32,13 +43,19 @@ export function ReusableCard({
   title,
   description,
   action,
+  isLast = false,
 }: {
   title: string;
   description: string;
   action: string;
+  isLast?: boolean;
 }) {
   return (
-    <Card className="my-2 w-full max-w-[370px] h-[110px] mx-auto">
+    <Card
+      className={`my-2 w-full max-w-[370px] h-[110px] mx-auto ${
+        isLast ? "mb-24 sm:mb-30" : ""
+      }`}
+    >
       <CardHeader className="flex items-center justify-between h-full">
         <div className="flex items-start gap-3">
           <Image


### PR DESCRIPTION

## PR description
Summary
- Convert hard-coded trending quiz cards into a data-driven list mapped to `ReusableCard`.
- Ensure the final card receives extra bottom spacing so it is not covered by the fixed bottom navbar.

What I changed
- TrendingQuiz.tsx
  - Introduced a `cards` array and replaced manual JSX with `cards.map(...)`.
  - Passed an `isLast` prop to the final mapped `ReusableCard`.
  - `ReusableCard` applies extra bottom margin when `isLast` is true (Tailwind classes `mb-24 sm:mb-30`).

Why
- Mapping makes the component data-driven and easier to extend/test.
- Adding bottom padding on the last card prevents it from being obscured by the fixed navbar on small screens (quick, low-risk fix).


 checklist
- [ ] Cards render from the `cards` array.
- [ ] Last card is not covered by the navbar on mobile and desktop.
- [ ] No visual regressions on other pages using `ReusableCard`.


<img width="426" height="819" alt="image" src="https://github.com/user-attachments/assets/b0152c63-9d6d-461e-bd89-15b78117ca5d" />
