### PR TITLE
fix(styles): refine global styles removing global borders & background blur to eliminate page glow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -191,8 +191,10 @@ body {
 }
 
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
+  /* Do not apply borders globally — add borders per-component where needed. */
+  /* Only show the outline for keyboard-focus-visible elements for accessibility */
+  :focus-visible {
+    @apply outline-ring/50;
   }
   body {
     @apply bg-background text-foreground;

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -19,7 +19,7 @@ function PlayPage() {
     >
       {/* Background Image */}
       <div
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat blur-sm"
+        className="absolute inset-0 bg-cover bg-center bg-no-repeat"
         style={{ backgroundImage: `url('/images/dashboard.svg')` }}
         aria-hidden="true"
       />
@@ -35,7 +35,10 @@ function PlayPage() {
         </div>
 
         {/* Main Card Container for PlayToday and UnfinishedQuizzesSection */}
-        <div className="bg-card rounded-t-2xl w-full mx-0 pt-6 pb-8 flex flex-col min-h-[calc(100vh-120px)] justify-between">
+        <div
+          className="bg-card rounded-t-2xl w-full mx-0 pt-6 pb-8 flex flex-col min-h-[calc(100vh-120px)] justify-between shadow-none border-0 outline-none"
+          style={{ boxShadow: "none", border: "none", outline: "none" }}
+        >
           <div>
             {/* What would you like to play today? Section */}
             <div className="space-y-4">


### PR DESCRIPTION

PR description
## Summary
Remove an unwanted four-sided glow on the Play page by stopping global border application and removing a full-viewport blur. Preserve keyboard accessibility by keeping focus-visible outlines.

## What I changed
- Removed the global border rule that applied a border to every element.
- Scoped the outline to `:focus-visible` only for keyboard users.
- Removed `blur-sm` from the Play page fullscreen background image.
- Added explicit `shadow-none`, `border-0`, and inline `boxShadow/border/outline: none` to the Play page main card to prevent residual glow.

## Why
A global border plus a blurred, full-viewport background produced a subtle white halo around the app (visible on the Play page). These edits remove the visual artifact while preserving accessible focus indication for keyboard users.

<img width="419" height="813" alt="image" src="https://github.com/user-attachments/assets/7415fdae-8169-45d4-a1e7-c16decdbe3b3" />



