### PR TITLE
Add API endpoints for user balance, header, and leaderboard data; integrate with leaderboard page

### DIFF
--- a/src/app/api/headerandbalance/balance/route.ts
+++ b/src/app/api/headerandbalance/balance/route.ts
@@ -1,0 +1,19 @@
+import prisma from "@/lib/prisma/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const balance = await prisma.user.findUnique({
+      where: {
+        id: "user-1-id",
+      },
+      select: {
+        balance: true,
+      },
+    });
+    return NextResponse.json(balance);
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to fetch user balance" }, { status: 500 });
+  }
+}
+

--- a/src/app/api/headerandbalance/header/route.ts
+++ b/src/app/api/headerandbalance/header/route.ts
@@ -1,0 +1,19 @@
+import prisma from "@/lib/prisma/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const header = await prisma.user.findUnique({
+      where: {
+        id: "user-1-id",
+      },
+      select: {
+        username: true,
+      },
+    });
+    return NextResponse.json(header);
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to fetch user header" }, { status: 500 });
+  }
+}
+

--- a/src/app/api/leaderboard/overallpoints/route.ts
+++ b/src/app/api/leaderboard/overallpoints/route.ts
@@ -1,0 +1,25 @@
+import prisma from "@/lib/prisma/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const totalPoints = await prisma.profileStats.findMany({
+      where: { overallPoints: { gt: 0 } },
+      orderBy: { overallPoints: "desc" },
+      include: { user: true },
+    });
+
+    // Map overallPoints to points for each entry
+    const mapped = totalPoints.map((entry) => ({
+      ...entry,
+      points: entry.overallPoints,
+    }));
+
+    return NextResponse.json(mapped);
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch overall points" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/leaderboard/points/route.ts
+++ b/src/app/api/leaderboard/points/route.ts
@@ -1,0 +1,16 @@
+import prisma from "@/lib/prisma/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const weeklyPoints = await prisma.rewards.findMany({
+      where: { points: { gt: 0 } },
+      orderBy: { points: "desc" },
+      include: { user: true },
+    });
+
+    return NextResponse.json(weeklyPoints);
+  } catch (error) {
+    return NextResponse.json({ error: "Failed to fetch weekly points" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
<img width="213" height="466" alt="image" src="https://github.com/user-attachments/assets/60eb68e0-92c1-404c-95a7-2374c89cb1ae" />

**Description:**  
This PR introduces and connects several backend API routes to the frontend leaderboard page:

- Adds `/api/headerandbalance/balance` endpoint to fetch a user's balance from the database.
- Adds `/api/headerandbalance/header` endpoint to fetch a user's username for the welcome header.
- Updates leaderboard endpoints (`/api/leaderboard/points` and `/api/leaderboard/overallPoints`) to return user data and points in the correct format.
- Refactors the leaderboard page to fetch and display the user's balance and username dynamically using the new API routes.
- Ensures all API routes use Prisma for database access and return JSON responses.
- Improves separation of concerns between mock data and live API data.

These changes enable real-time display of user balance and username in the leaderboard UI, and ensure leaderboard data is fetched from the backend.