### PR TITLE
feat(dashboard): extract TrendingQuizzesList, pass cards via props & use light card border

### DIFF
--- a/src/components/dashboard/TrendingQuiz.tsx
+++ b/src/components/dashboard/TrendingQuiz.tsx
@@ -1,11 +1,4 @@
-import {
-  Card,
-  CardAction,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import Image from "next/image";
+import TrendingQuizzesList from "./TrendingQuizzesList";
 
 export default function TrendingQuiz() {
   const cards: { title: string; description: string; action: string }[] = [
@@ -23,58 +16,7 @@ export default function TrendingQuiz() {
   return (
     <div className="border border-gray-200 bg-white rounded-t-xl p-4 shadow-sm">
       <h1 className="text-2xl font-semibold mx-2 my-2">Trending Quizzes</h1>
-      {/* center the card list so each card can use mx-auto / max-w on small screens */}
-      <div className="flex flex-col items-center">
-        {cards.map((c, i) => (
-          <ReusableCard
-            key={`${c.title}-${c.action}-${i}`}
-            title={c.title}
-            description={c.description}
-            action={c.action}
-            isLast={i === cards.length - 1}
-          />
-        ))}
-      </div>
+      <TrendingQuizzesList cards={cards} />
     </div>
-  );
-}
-
-export function ReusableCard({
-  title,
-  description,
-  action,
-  isLast = false,
-}: {
-  title: string;
-  description: string;
-  action: string;
-  isLast?: boolean;
-}) {
-  return (
-    <Card
-      className={`my-2 w-full max-w-[370px] h-[110px] mx-auto ${
-        isLast ? "mb-24 sm:mb-30" : ""
-      }`}
-    >
-      <CardHeader className="flex items-center justify-between h-full">
-        <div className="flex items-start gap-3">
-          <Image
-            src="/cube1.svg"
-            alt="cube"
-            width={48}
-            height={38}
-            className="rounded"
-          />
-          <div>
-            <CardTitle className="text-lg sm:text-2xl">{title}</CardTitle>
-            <CardDescription>{description}</CardDescription>
-          </div>
-        </div>
-        <CardAction className="flex flex-col items-center font-semibold">
-          <span className="text-lg">{action}</span>
-          <span className="text-sm font-normal text-gray-500">Plays</span>
-        </CardAction>
-      </CardHeader>
-    </Card>
   );
 }

--- a/src/components/dashboard/TrendingQuizzesList.tsx
+++ b/src/components/dashboard/TrendingQuizzesList.tsx
@@ -1,0 +1,68 @@
+import Image from "next/image";
+import {
+  Card,
+  CardAction,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function TrendingQuizzesList({
+  cards,
+}: {
+  cards: { title: string; description: string; action: string }[];
+}) {
+  return (
+    <div className="flex flex-col items-center">
+      {cards.map((c, i) => (
+        <TrendingCard
+          key={`${c.title}-${c.action}-${i}`}
+          title={c.title}
+          description={c.description}
+          action={c.action}
+          isLast={i === cards.length - 1}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function TrendingCard({
+  title,
+  description,
+  action,
+  isLast = false,
+}: {
+  title: string;
+  description: string;
+  action: string;
+  isLast?: boolean;
+}) {
+  return (
+    <Card
+      className={`my-2 w-full max-w-[370px] h-[110px] mx-auto ${
+        isLast ? "mb-24 sm:mb-32" : ""
+      }`}
+    >
+      <CardHeader className="flex items-center justify-between h-full">
+        <div className="flex items-start gap-3">
+          <Image
+            src="/cube1.svg"
+            alt="cube"
+            width={48}
+            height={38}
+            className="rounded"
+          />
+          <div>
+            <CardTitle className="text-lg sm:text-2xl">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+        </div>
+        <CardAction className="flex flex-col items-center font-semibold">
+          <span className="text-lg">{action}</span>
+          <span className="text-sm font-normal text-gray-500">Plays</span>
+        </CardAction>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,18 +1,18 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-gray-200 py-6 shadow-sm",
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -35,7 +35,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("leading-none font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -45,7 +45,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -58,7 +58,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -68,7 +68,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -78,7 +78,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -89,4 +89,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};


### PR DESCRIPTION
### PR description
Summary
- Extracts the Trending quizzes list into a new component TrendingQuizzesList.tsx.
- Makes `TrendingQuizzesList` accept an array of quiz card objects as a prop.
- Moves the cards array into TrendingQuiz.tsx and passes it down to the list component.
- Replaces the heavy/black-looking card border with a light border (`border-gray-200`) in the shared `Card` UI component.
- Cleans up unused imports in TrendingQuiz.tsx.

Why
- Separates data from presentation, making the trending list reusable and testable.
- Fixes UI inconsistency (black border on cards) by standardizing the card border color.
- Reduces unused imports and improves clarity.

