### PR TITLE
feat: use global CSS variable for SearchBar background & improve typing UX

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,6 +22,13 @@
   --destructive-foreground: hsl(0 0% 100%);
   --border: hsl(240 17.0732% 91.9608%);
   --input: hsl(0 0% 92.1569%);
+  /* Background used for search / subtle input surfaces. Uses a lightly transparent mix of --input.
+    We provide a fallback to --input for older browsers that don't support color-mix. */
+  --search-input-bg: color-mix(
+    in srgb,
+    var(--input) 20%,
+    rgba(255, 255, 255, 0)
+  );
   --ring: hsl(0 0% 0%);
   --chart-1: hsl(148.0952 53.3898% 53.7255%);
   --chart-2: hsl(257.9412 100% 60%);
@@ -85,6 +92,8 @@
   --destructive-foreground: hsl(0 0% 100%);
   --border: hsl(222.8571 6.422% 21.3725%);
   --input: hsl(222.8571 6.422% 21.3725%);
+  /* Dark mode search background — slightly transparent mix of --input */
+  --search-input-bg: color-mix(in srgb, var(--input) 18%, rgba(0, 0, 0, 0));
   --ring: hsl(257.6687 100% 68.0392%);
   --chart-1: hsl(141.8919 69.1589% 58.0392%);
   --chart-2: hsl(257.6687 100% 68.0392%);

--- a/src/components/searchpage/SearchBar.tsx
+++ b/src/components/searchpage/SearchBar.tsx
@@ -4,7 +4,8 @@ export default function SearchBar() {
   return (
     <div className="flex justify-center items-center mt-8 mb-4">
       <Input
-        className="w-72 h-18 rounded-md bg-input/20  backdrop-blur-lg border-none placeholder:text-background placeholder:text-sm placeholder: font-mono"
+        style={{ backgroundColor: "var(--search-input-bg, var(--input))" }}
+        className="w-72 max-w-full h-18 rounded-md backdrop-blur-lg border-none placeholder:text-white/60 placeholder:text-sm font-mono text-white caret-white transition duration-200 ease-in-out focus:ring-0 focus-visible:ring-0 focus:border-transparent focus-visible:border-transparent focus:shadow-none"
         placeholder="Search Quizzes"
       />
     </div>


### PR DESCRIPTION


### PR description 

Summary
- Use a centralized CSS variable for the SearchBar background instead of hardcoded colors, and improve the typing experience by ensuring white input text/caret and smooth transitions.

Motivation
- Previously the SearchBar used inline/hardcoded background or inconsistent styles causing visual drift across themes and a black border/text when typing. Centralizing the background color into `:root` / `.dark` variables keeps colors consistent with the theme and makes future adjustments easier.

What changed
- Added a `--search-input-bg` variable (light/dark values) in globals.css. It uses a subtle mix of the existing `--input` color and falls back to `--input` when necessary.
- Updated SearchBar.tsx to:
  - use `--search-input-bg` via inline style (with fallback),
  - force typed text to be white and set `caret-white`,
  - remove the heavy focus border and keep smooth transition behavior.
- No hardcoded hex/HSL colors were added in the component; color comes from global variables.



Acceptance criteria
- [ ] Search input background is taken from `--search-input-bg` (no hardcoded color in component).
- [ ] Typed text is white; caret is white and clearly visible in both light and dark modes.
- [ ] No black/dark border appears on focus while typing.
- [ ] Transitions for focus/typing are smooth (no abrupt jumps).
- [ ] Desktop and mobile spacing/layout unaffected.
