### PR TITLE
Add latest quizzes API route, frontend integration, and quiz seeder

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "typescript": "^5.9.2"
   },
   "prisma": {
-    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seeder/seed.ts"
+    "prisma": {
+      "seed": "ts-node prisma/seeder/mainSeeder.ts"
+    }
   }
 }

--- a/prisma/seeder/mainSeeder.ts
+++ b/prisma/seeder/mainSeeder.ts
@@ -1,0 +1,6 @@
+import "./profileStatsSeed";
+import "./quizSeed";
+import "./rewardSeed";
+import "./userSeed";
+
+console.log("All seeders executed.");

--- a/prisma/seeder/quizSeed.ts
+++ b/prisma/seeder/quizSeed.ts
@@ -1,0 +1,100 @@
+import { PrismaClient } from "../../src/generated/prisma";
+
+const prisma = new PrismaClient();
+
+async function seedQuizzes() {
+  await prisma.quiz.create({
+    data: {
+      title: "DEX vs CEX",
+      category: "Exchange",
+      questions: {
+        create: Array.from({ length: 20 }, (_, i) => ({
+          text: `DEX vs CEX Question ${i + 1}`,
+        })),
+      },
+    },
+  });
+
+  await prisma.quiz.create({
+    data: {
+      title: "Unstable Coin",
+      category: "Cryptocurrency",
+      questions: {
+        create: Array.from({ length: 20 }, (_, i) => ({
+          text: `Unstable Coin Question ${i + 1}`,
+        })),
+      },
+    },
+  });
+
+  await prisma.quiz.create({
+    data: {
+      title: "Blockchain Basics",
+      category: "Technology",
+      questions: {
+        create: Array.from({ length: 20 }, (_, i) => ({
+          text: `Blockchain Basics Question ${i + 1}`,
+        })),
+      },
+    },
+  });
+
+  await prisma.quiz.create({
+    data: {
+      title: "Smart Contracts",
+      category: "Development",
+      questions: {
+        create: Array.from({ length: 20 }, (_, i) => ({
+          text: `Smart Contracts Question ${i + 1}`,
+        })),
+      },
+    },
+  });
+
+  await prisma.quiz.create({
+    data: {
+      title: "NFTs Explained",
+      category: "Digital Assets",
+      questions: {
+        create: Array.from({ length: 20 }, (_, i) => ({
+          text: `NFTs Explained Question ${i + 1}`,
+        })),
+      },
+    },
+  });
+
+  await prisma.quiz.create({
+    data: {
+      title: "Crypto Security",
+      category: "Security",
+      questions: {
+        create: Array.from({ length: 20 }, (_, i) => ({
+          text: `Crypto Security Question ${i + 1}`,
+        })),
+      },
+    },
+  });
+
+  await prisma.quiz.create({
+    data: {
+      title: "DeFi Deep Dive",
+      category: "Finance",
+      questions: {
+        create: Array.from({ length: 20 }, (_, i) => ({
+          text: `DeFi Deep Dive Question ${i + 1}`,
+        })),
+      },
+    },
+  });
+
+  console.log("Quizzes seeded successfully.");
+}
+
+seedQuizzes()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/api/search/latestaddedquizzes/route.ts
+++ b/src/app/api/search/latestaddedquizzes/route.ts
@@ -1,0 +1,23 @@
+import prisma from "@/lib/prisma/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET(){
+    try{
+        const quizzes = await prisma.quiz.findMany({
+            orderBy:{
+                createdAt: "desc",
+            },
+            take: 6,
+            include:{
+                questions: true,
+                attempts: true,
+            }
+        });
+        if(quizzes.length === 0){
+            return NextResponse.json({error:"No quizzes found"},{status:404})
+        }
+        return NextResponse.json({quiz: quizzes},{status:200})
+        }catch(error){
+            return NextResponse.json({error:"Something went wrong"},{status:500})
+    }
+}

--- a/src/components/searchpage/LatestTab.tsx
+++ b/src/components/searchpage/LatestTab.tsx
@@ -1,17 +1,47 @@
+"use client";
+
 import Image from "next/image";
+import { useEffect, useState } from "react";
+
+interface Quiz {
+  category: string;
+  questions: { length: number }[];
+  attempts: Record<string, unknown>[];
+}
 
 export default function LatestTab() {
-  const cards = [
-    { title: "DEX vs CEX", description: "20 questions", plays: "1234" },
-    { title: "Unstable Coin", description: "20 questions", plays: "1204" },
-    { title: "DEX vs CEX", description: "20 questions", plays: "1234" },
-    { title: "DEX vs CEX", description: "20 questions", plays: "1234" },
-  ];
+  const [quizzes, setQuizzes] = useState<Quiz[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchQuizzes = async () => {
+      try {
+        const res = await fetch("/api/search/latestaddedquizzes");
+        const data = await res.json();
+
+        if (!res.ok) {
+          setError(data.error || "Something went wrong");
+        } else {
+          setQuizzes(data.quiz);
+        }
+      } catch (err) {
+        setError("Failed to fetch quizzes");
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchQuizzes();
+  }, []);
+
+  if (loading) return <div>Loading quizzes...</div>;
+  if (error) return <div>{error}</div>;
 
   return (
     <div className="mt-4 px-4">
       <div className="flex flex-col gap-4 w-full min-w-[370px] mx-auto">
-        {cards.map((card, idx) => (
+        {quizzes.map((quiz: Quiz, idx: number) => (
           <div
             key={idx}
             className="w-full rounded-3xl px-5 py-4 shadow-sm bg-white border border-gray-100"
@@ -31,14 +61,16 @@ export default function LatestTab() {
               {/* Title + Description */}
               <div className="flex-1 min-w-0">
                 <p className="text-lg sm:text-2xl font-semibold text-gray-900">
-                  {card.title}
+                  {quiz.category}
                 </p>
-                <p className="text-sm text-gray-500">{card.description}</p>
+                <p className="text-sm text-gray-500">
+                  {quiz.questions.length} questions
+                </p>
               </div>
               {/* Plays */}
               <div className="flex flex-col items-end justify-center flex-shrink-0">
                 <span className="text-lg font-semibold text-gray-900">
-                  {card.plays}
+                  {quiz.attempts.length}
                 </span>
                 <span className="text-sm font-normal text-gray-500">Plays</span>
               </div>


### PR DESCRIPTION

<img width="213" height="461" alt="image" src="https://github.com/user-attachments/assets/09112888-598e-43f0-b704-25983ef7bf91" />

**Description:**  
- Implemented `GET /api/search/latestaddedquizzes` API route to fetch the latest quizzes from the database, including questions and attempts.
- Updated the frontend LatestTab.tsx component to fetch and display quizzes from the new API route, with improved type safety and error handling.
- Added and executed a comprehensive quiz seeder (`quizSeed.ts`) to populate the database with sample quizzes for development and testing.

This PR enables dynamic display of the latest quizzes and ensures the backend and frontend are properly connected for quiz data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Latest tab now displays the most recently added quizzes, fetched dynamically.
  * Added loading and error states for a smoother experience when fetching data.
  * Each quiz shows its category, number of questions, and play count.

* Chores
  * Updated database seeding configuration and added seeding scripts to populate quizzes and related data.
  * Introduced a backend endpoint to serve the latest quizzes to the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->