### PR TITLE
feat: implement GET endpoint for recent quiz attempts based on wallet…

### DIFF
--- a/src/app/api/dashboard/recentquiz/route.ts
+++ b/src/app/api/dashboard/recentquiz/route.ts
@@ -1,0 +1,46 @@
+import prisma from "@/lib/prisma/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const wallet = searchParams.get("wallet");
+
+  if (!wallet) {
+    return NextResponse.json({ error: "Unauthorised" }, { status: 401 });
+  }
+  try {
+    const username = await prisma.user.findUnique({
+      where: {
+        walletAddress: wallet,
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (!username) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+    const recentquiz = await prisma.quizAttempt.findFirst({
+      where: {
+        userId: username.id,
+      },
+      orderBy:{
+        createdAt: "desc",
+      },
+      select:{
+        quizId: true,
+        quiz:{
+            select:{
+                title:true,
+            }
+        }
+      }
+    });
+    return NextResponse.json({ recentquiz });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION

<img width="656" height="348" alt="image" src="https://github.com/user-attachments/assets/45531ca9-ef36-4872-b4e4-59a63889a175" />

**Description:**  
- Implemented a new API endpoint to fetch the most recent quiz attempt for a user based on their wallet address.
- Returns quiz ID and quiz title, ordered by latest attempt.
- Handles unauthorized access, user not found, and internal server errors with appropriate status codes and messages.
- Uses Prisma for database queries and Next.js API response structure.