### PR TITLE
feat: transparent profile tabs with bold labels and white active underline

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -45,7 +45,7 @@ export default function ProfilePage() {
         {/* Tabs Section */}
         <div className="px-6">
           <Tabs defaultValue="details" className="w-full">
-            <TabsList className="grid w-full grid-cols-4 bg-white/80 backdrop-blur-sm">
+            <TabsList className="grid w-full grid-cols-4 bg-transparent">
               <TabsTrigger value="details" className="text-sm">
                 Details
               </TabsTrigger>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "inline-flex h-9 w-fit items-end justify-center rounded-none p-0",
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 text-chart-5 data-[state=active]:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-foreground",
+        "inline-flex h-full flex-1 items-center justify-center gap-1.5 px-4 py-2 text-sm font-bold whitespace-nowrap transition-all focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 text-white/60 border-b-2 border-transparent data-[state=active]:text-white data-[state=active]:border-white",
         className
       )}
       {...props}


### PR DESCRIPTION
Summary
- Update profile page tab UI to match the provided visual spec: fully transparent tab bar, subtle faded inactive labels, bold active label, and a clear white underline for the active tab.
- No new global CSS variables were added; existing theme tokens are used.

What  changed
- tabs.tsx
  - Made `TabsList` layout neutral (transparent by default) and aligned items to the bottom so the underline is visible.
  - Updated `TabsTrigger` to use:
    - inactive: `text-white/60`
    - active: `text-white` and `border-white` for the underline
    - `font-bold` to make labels bold
    - `border-b-2 border-transparent` so underline only appears for active state
- page.tsx
  - Removed the fixed white tint from the `TabsList` (now `bg-transparent`) so the tab bar sits over the page background.

Why
- Matches the design reference: transparent tabs over the purple background, faded inactive text, bold active label with a white underline.
- Keeps theme consistency by using existing tokens and avoids adding new global variables or colors.


<img width="297" height="50" alt="image" src="https://github.com/user-attachments/assets/abbe4258-32bf-4075-9624-8381f8254913" />
