### PR TITLE
Redirect users to dashboard after wallet connection and improve authentication flow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,19 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useUser } from "@/context/userContext";
+
 export default function Home() {
-  return (
-    <>
-    </>
-  );
+  const router = useRouter();
+  const { address } = useUser();
+
+  useEffect(() => {
+    if (address) {
+      router.replace("/dashboard");
+    } else {
+      router.replace("/login");
+    }
+  }, [address, router]);
+
+  return null;
 }

--- a/src/components/custom/common/WalletLoginButton.tsx
+++ b/src/components/custom/common/WalletLoginButton.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useAccount } from "wagmi";
 
 function WalletLoginButton() {
   const { address, isConnected } = useAccount();
+  const router = useRouter();
 
   useEffect(() => {
     if (isConnected && address) {
@@ -21,11 +23,12 @@ function WalletLoginButton() {
           }
           // Token is set via HttpOnly cookie by the server.
           console.log("Wallet synced.");
+          router.replace("/dashboard");
           return res.json().catch(() => ({}));
         })
         .catch((err) => console.error(err));
     }
-  }, [isConnected, address]);
+  }, [isConnected, address, router]);
 
   return (
     <div className="px-4 mt-40">


### PR DESCRIPTION

**Description:**  
- Added client-side redirect logic to the root page (page.tsx) to send unauthenticated users to the login page and authenticated users to the dashboard.
- Updated the wallet connect button (WalletLoginButton.tsx) to automatically redirect users to the dashboard after successful wallet connection.
- Ensured authentication state is checked using the wallet address from context.
- Improved user experience by streamlining navigation based on authentication status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home now automatically redirects: signed-in users go to the dashboard; others are sent to the login page.
  * After a successful wallet login, users are taken directly to the dashboard.

* **Bug Fixes**
  * Improves reliability of post-login navigation to ensure users consistently land on the dashboard after authenticating with a wallet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->