### PR TITLE
feat: add PlayersTab component to render a ranked list of players 

### DIFF
--- a/src/components/play/mockPlayers.ts
+++ b/src/components/play/mockPlayers.ts
@@ -1,0 +1,18 @@
+export type Player = {
+  id: string;
+  rank: number;
+  name: string;
+  xp: number;
+};
+
+// Simple mock data matching the attached screenshot ordering and XP values
+export const mockPlayers: Player[] = [
+  { id: "p1", rank: 1, name: "Jesica", xp: 22 },
+  { id: "p2", rank: 2, name: "Elsa", xp: 22 },
+  { id: "p3", rank: 3, name: "Felix", xp: 28 },
+  { id: "p4", rank: 4, name: "Jordan", xp: 22 },
+  { id: "p5", rank: 5, name: "Holland", xp: 32 },
+  { id: "p6", rank: 6, name: "Robert", xp: 22 },
+];
+
+export default mockPlayers;

--- a/src/components/play/playersTab.tsx
+++ b/src/components/play/playersTab.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { User2 } from "lucide-react";
+import mockPlayers from "./mockPlayers";
+
+type Props = {
+  className?: string;
+};
+
+// Contract: renders a simple ranked list of players with avatar, name and XP.
+// Inputs: optional className; Data: uses internal mockPlayers array.
+// Output: a styled list that reads color tokens from global.css.
+
+export default function PlayersTab({ className = "" }: Props) {
+  return (
+    <div className={"w-full px-10 sm:px-14 " + className}>
+      {/* Use vertical spacing instead of borders to avoid a table-like look */}
+      <ul className="space-y-3 list-none m-0 p-0">
+        {mockPlayers.map((p) => (
+          <li
+            key={p.id}
+            className="flex items-center justify-between px-0 py-3 sm:py-4"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="w-11 text-sm font-bold"
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                {String(p.rank).padStart(2, "0")}
+              </div>
+
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center"
+                style={{
+                  background: "var(--muted)",
+                  color: "var(--muted-foreground)",
+                }}
+                aria-hidden
+              >
+                <User2 size={18} />
+              </div>
+
+              <div
+                className="text-sm font-medium"
+                style={{ color: "var(--foreground)" }}
+              >
+                {p.name}
+              </div>
+            </div>
+
+            <div
+              className="text-sm font-semibold"
+              style={{ color: "var(--foreground)" }}
+            >
+              XP {p.xp}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION

## PR Description
Summary
- Replace the old implementation with a simple, elegant players list that matches the provided mockshot.
- Add stable mock data and wire it to the component so the list renders locally without external API calls.

What changed
- Added mock data
  - mockPlayers.ts — Player mock dataset used by the component
- Reworked component
  - playersTab.tsx
    - Replaced styled-jsx with Tailwind utility classes and inline `var(...)` usage for colors.
    - Uses `User2` from `lucide-react` for the avatar icon.
    - Removes per-item dividers and uses vertical spacing (avoids table-like look).
    - Increased horizontal margin/padding: outer wrapper uses `px-10 sm:px-14`.
    - Keeps colors sourced from existing CSS variables (`--muted`, `--muted-foreground`, `--foreground`) — no changes to globals.css.

Why
- Makes the players list simple to preview with consistent data.
- Improves visual alignment, spacing, and avoids a table-like appearance.
- Uses design tokens already present in globals.css to ensure theme/dark-mode compatibility.



<img width="429" height="516" alt="image" src="https://github.com/user-attachments/assets/66563288-2b4d-4d24-9b7e-739bdc478df0" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a Players tab that displays a ranked leaderboard.
  * Shows zero-padded ranks, player names, and XP for quick comparison.
  * Includes circular avatar placeholders for visual clarity.
  * Smooth, responsive layout with improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->