### PR TITLE
feat: implement RewardTab component to display prize distribution 

### DIFF
--- a/src/components/play/RewardTab.tsx
+++ b/src/components/play/RewardTab.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { mockPrizePool, mockRewardDistribution } from "@/lib/data/mockData";
+
+interface RewardTabProps {
+  className?: string;
+}
+
+const fontSizes = [22, 18, 16, 14, 12]; // decreasing sizes for ranks
+
+export const RewardTab: React.FC<RewardTabProps> = ({ className }) => {
+  return (
+    <div
+      className={
+        "w-full max-w-md mx-auto bg-card rounded-2xl shadow-none p-4 border-0" +
+        (className ? ` ${className}` : "")
+      }
+      style={{
+        color: "var(--color-foreground)",
+        border: "none",
+        boxShadow: "none",
+        borderBottom: "none",
+      }}
+      role="region"
+      aria-label="Prize distribution"
+    >
+      <div className="flex justify-between items-center mb-2">
+        <div
+          className="text-sm font-bold"
+          style={{ color: "var(--circular-fill)", letterSpacing: "0.01em" }}
+        >
+          Total Prize Pool
+        </div>
+
+        <div
+          className="text-sm font-semibold"
+          style={{ color: "var(--circular-fill)", letterSpacing: "0.01em" }}
+        >
+          {mockPrizePool.amount} {mockPrizePool.currency}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {mockRewardDistribution.map((r, idx) => {
+          const fontSize = fontSizes[idx] ?? 12;
+          return (
+            <div
+              key={r.id}
+              className="flex items-center justify-between"
+              style={{ padding: "6px 2px" }}
+            >
+              <div className="truncate">
+                <div
+                  className="font-medium"
+                  style={{ fontSize: `${fontSize}px`, lineHeight: 1 }}
+                >
+                  {r.label}
+                </div>
+              </div>
+
+              <div
+                className="flex items-center justify-end"
+                style={{ minWidth: 72 }}
+              >
+                <div
+                  className="font-semibold"
+                  style={{ fontSize: `${Math.max(12, fontSize - 2)}px` }}
+                >
+                  {r.percent}%
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default RewardTab;

--- a/src/lib/data/mockData.ts
+++ b/src/lib/data/mockData.ts
@@ -235,3 +235,23 @@ export const playUnfinishedQuizzes: UnfinishedQuiz[] = [
     image: "/public/images/playQuizImage.svg",
   },
 ];
+
+// Reward distribution mock data (derived from provided design)
+export interface RewardShare {
+  id: string;
+  label: string;
+  percent: number; // percent share as a number (e.g. 25 for 25%)
+}
+
+export const mockPrizePool = {
+  amount: 132,
+  currency: "USDC",
+};
+
+export const mockRewardDistribution: RewardShare[] = [
+  { id: "r1", label: "Rank 1", percent: 25 },
+  { id: "r2", label: "Rank 2", percent: 15 },
+  { id: "r3", label: "Rank 3", percent: 12 },
+  { id: "r4to10", label: "Rank 4 to 10", percent: 3.57 },
+  { id: "remaining", label: "Remaining Players", percent: 0.144 },
+];


### PR DESCRIPTION


## PR description
Summary
- Adds a mobile-first, theme-aware `RewardTab` component to display prize distribution (decreasing font sizes per rank) and the corresponding mock data used for the view. Removes the unwanted bottom border/visual stroke and uses existing CSS variables (no new global CSS).

What  changed
- Added RewardTab.tsx
  - Mobile-first layout
  - Decreasing font sizes per rank
  - No left circular marker (removed)
  - Prize pool label and amount use `--circular-fill`
  - Removed card shadow/border that produced the rounded bottom stroke
- Updated mockData.ts
  - Added `mockPrizePool` and `mockRewardDistribution` 
  
  
  
<img width="423" height="270" alt="image" src="https://github.com/user-attachments/assets/20d21246-ee27-474a-ab1d-05b47d72d4dc" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Reward tab that displays the total prize pool and a clear breakdown of prize distribution by rank.
  * Responsive typography emphasizes higher ranks and presents percentages right-aligned for quick scanning.
  * Includes accessible labeling for assistive technologies and a polished card-style layout.

* **Chores**
  * Added mock prize pool and reward distribution data to power the new Reward tab experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->