### PR TITLE
feat: Integrate PlayTab component for enhanced gameplay options and UI improvements

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -2,13 +2,8 @@
 import React from "react";
 import WelcomeHeader from "@/components/dashboard/WelcomeHeader";
 import BalanceCard from "@/components/dashboard/BalanceCard";
-import PlayToday from "@/components/play/playToday";
-import {
-  playToday,
-  playUnfinishedQuizzes,
-} from "@/lib/data/mockData";
-import UnfinishedQuizzes from "@/components/play/unfinishedQuizzes";
 import { useUser } from "@/context/userContext";
+import PlayTab from "@/components/play/playtab";
 
 function PlayPage() {
   const { username, balance } = useUser();
@@ -26,7 +21,10 @@ function PlayPage() {
       />
 
       {/* Content */}
-      <div className="relative z-10 pb-safe-area-bottom">
+      <div
+        className="relative z-10"
+        style={{ paddingBottom: "calc(72px + env(safe-area-inset-bottom))" }}
+      >
         {/* Header Section with Welcome and Balance */}
         <div className="px-6 pt-12 pb-8">
           <div className="flex items-start justify-between gap-4">
@@ -41,15 +39,8 @@ function PlayPage() {
           style={{ boxShadow: "none", border: "none", outline: "none" }}
         >
           <div>
-            {/* What would you like to play today? Section */}
-            <div className="space-y-4">
-              <PlayToday/>
-            </div>
-
-            {/* Your Unfinished Quizzes Section */}
-            <div className="space-y-4">
-              <UnfinishedQuizzes/>
-            </div>
+            {/* tab */}
+            <PlayTab />
           </div>
           {/* This empty div ensures the container stretches to the bottom */}
           <div></div>

--- a/src/components/play/playtab.tsx
+++ b/src/components/play/playtab.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import PlayersTab from "./playersTab";
 
 type TabKey = "players" | "reward";
 
@@ -15,8 +16,12 @@ export default function PlayTab() {
           onClick={() => setActive("players")}
           className={`pb-3 text-lg font-semibold transition-colors outline-none focus:outline-none border-b-2`}
           style={{
-            color: active === "players" ? "var(--primary)" : "var(--muted-foreground)",
-            borderBottomColor: active === "players" ? "var(--primary)" : "transparent",
+            color:
+              active === "players"
+                ? "var(--primary)"
+                : "var(--muted-foreground)",
+            borderBottomColor:
+              active === "players" ? "var(--primary)" : "transparent",
           }}
         >
           Players
@@ -27,8 +32,12 @@ export default function PlayTab() {
           onClick={() => setActive("reward")}
           className={`pb-3 text-lg font-semibold transition-colors outline-none focus:outline-none border-b-2`}
           style={{
-            color: active === "reward" ? "var(--primary)" : "var(--muted-foreground)",
-            borderBottomColor: active === "reward" ? "var(--primary)" : "transparent",
+            color:
+              active === "reward"
+                ? "var(--primary)"
+                : "var(--muted-foreground)",
+            borderBottomColor:
+              active === "reward" ? "var(--primary)" : "transparent",
           }}
         >
           Reward
@@ -40,23 +49,22 @@ export default function PlayTab() {
         {active === "players" ? (
           <div>
             <div
-              className="rounded-2xl border-2 p-4 text-sm max-w-full"
+              className=" text-sm max-w-full"
               style={{
                 backgroundColor: "var(--quiz-card-bg)",
-                borderColor: "var(--quiz-card-border)",
                 color: "var(--quiz-subtitle-color)",
               }}
             >
               {/* PlayerTab component will be rendered here. */}
+              <PlayersTab />
             </div>
           </div>
         ) : (
           <div>
             <div
-              className="rounded-2xl border-2 p-4 text-sm max-w-full"
+              className=" text-sm max-w-full"
               style={{
                 backgroundColor: "var(--quiz-card-bg)",
-                borderColor: "var(--quiz-card-border)",
                 color: "var(--quiz-subtitle-color)",
               }}
             >


### PR DESCRIPTION

## PR description
Summary
- Remove the rounded card/border around the Players tab so the players list no longer shows a rounded border.
- Prevent the fixed bottom navbar from covering the bottom of the Players list by adding page-local bottom padding (no global CSS changes).

Files changed
- playtab.tsx — removed `rounded-2xl` and `border-2` from the PlayTab wrapper so PlayersTab is no longer rendered inside a rounded/bordered card.
- page.tsx — added inline bottom padding (uses `calc(72px + env(safe-area-inset-bottom))`) on the play page content wrapper to ensure content is not hidden behind the fixed bottom navbar.



Why
- The visible rounded border was coming from the PlayTab wrapper, not the Players list itself. Removing the wrapper border fixes the visual.
- The fixed bottom navbar (z-50) was overlapping page content; adding bottom padding to the page prevents the 6th player from being covered while preserving the navbar behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified Play experience with a single tabbed view replacing separate “Today” and “Unfinished” sections.
  - Introduced a Players tab within the Play view.
  - Improved bottom safe-area handling for better spacing on devices with insets.

- Style
  - Simplified panel styling, reducing borders and visual noise for a cleaner look.

- Refactor
  - Streamlined Play page structure to render the new tabbed interface directly, removing redundant sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->