### PR TITLE
feat: add JoinedContests component to display user joined contests

### DIFF
--- a/src/app/api/play/joinedContest/route.ts
+++ b/src/app/api/play/joinedContest/route.ts
@@ -17,6 +17,9 @@ export async function GET(req: Request) {
   }
 
   const wallet = decoded.wallet;
+  if (!wallet) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   try {
     const joinedContest = await prisma.contestParticipant.findMany({
@@ -49,7 +52,7 @@ export async function GET(req: Request) {
         timeleftinhours,
       };
     });
-    return NextResponse.json(timetobegincontest)
+    return NextResponse.json(timetobegincontest);
   } catch (err) {
     console.error(err);
     return NextResponse.json(

--- a/src/app/api/play/joinedContest/route.ts
+++ b/src/app/api/play/joinedContest/route.ts
@@ -1,0 +1,60 @@
+import { verifyToken } from "@/lib/auth";
+import prisma from "@/lib/prisma/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  const cookieHeader = req.headers.get("cookie") || "";
+  const match = cookieHeader.match(/token=([^;]+)/);
+  const token = match ? match[1] : null;
+
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorised Access" }, { status: 401 });
+  }
+
+  const decoded = verifyToken(token);
+  if (!decoded) {
+    return NextResponse.json({ error: "Token is expired" }, { status: 401 });
+  }
+
+  const wallet = decoded.wallet;
+
+  try {
+    const joinedContest = await prisma.contestParticipant.findMany({
+      where: {
+        user: {
+          walletAddress: wallet,
+        },
+      },
+      select: {
+        contest: {
+          select: {
+            name: true,
+            startTime: true,
+            _count: {
+              select: {
+                participants: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    // Calculate time left for each contest
+    const timetobegincontest = joinedContest.map((item) => {
+      const contest = item.contest;
+      const timeleftinhours =
+        (new Date(contest.startTime).getTime() - Date.now()) / (1000 * 60 * 60); // hours
+      return {
+        ...contest,
+        timeleftinhours,
+      };
+    });
+    return NextResponse.json(timetobegincontest)
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -3,12 +3,8 @@ import React from "react";
 import WelcomeHeader from "@/components/dashboard/WelcomeHeader";
 import BalanceCard from "@/components/dashboard/BalanceCard";
 import PlayToday from "@/components/play/playToday";
-import {
-  playToday,
-  playUnfinishedQuizzes,
-} from "@/lib/data/mockData";
-import UnfinishedQuizzes from "@/components/play/unfinishedQuizzes";
 import { useUser } from "@/context/userContext";
+import JoinedContests from "@/components/play/joined-contests";
 
 function PlayPage() {
   const { username, balance } = useUser();
@@ -48,7 +44,7 @@ function PlayPage() {
 
             {/* Your Unfinished Quizzes Section */}
             <div className="space-y-4">
-              <UnfinishedQuizzes/>
+              <JoinedContests/>
             </div>
           </div>
           {/* This empty div ensures the container stretches to the bottom */}

--- a/src/components/play/joined-contests.tsx
+++ b/src/components/play/joined-contests.tsx
@@ -1,0 +1,152 @@
+"use client";
+import Image from "next/image";
+import React from "react";
+
+interface JoinedContest {
+  name: string;
+  participants: number;
+  timeleftinhours: number;
+}
+
+// Dummy data for UI preview
+const joinedContests: JoinedContest[] = [
+  {
+    name: "DEX vs CEX",
+    participants: 158,
+    timeleftinhours: 12,
+  },
+  {
+    name: "Unstable Coin",
+    participants: 20,
+    timeleftinhours: 12,
+  },
+  {
+    name: "DEX vs CEX",
+    participants: 20,
+    timeleftinhours: 24,
+  },
+  {
+    name: "DEX vs CEX",
+    participants: 20,
+    timeleftinhours: 20,
+  },
+];
+
+export default function JoinedContests() {
+  return (
+    <div className="px-6 mt-8 pb-24">
+      <h3
+        className="text-lg font-semibold mb-4 font-sans"
+        style={{ color: "var(--card-foreground)" }}
+      >
+        Contests you have joined
+      </h3>
+      <div className="space-y-4">
+        {joinedContests.map((contest, idx) => (
+          <div
+            key={idx}
+            className="flex items-center rounded-xl px-4 py-4 shadow-sm min-h-[80px]"
+            style={{
+              backgroundColor: "var(--quiz-card-bg)",
+              border: "1px solid var(--quiz-card-border)",
+            }}
+          >
+            {/* Left Icon */}
+            <div className="flex-shrink-0">
+              <Image
+                src="/cube1.svg"
+                alt="Contest Icon"
+                width={48}
+                height={48}
+                className="object-contain"
+                priority
+              />
+            </div>
+            {/* Contest Info */}
+            <div className="flex-1 ml-4">
+              <div
+                className="text-lg font-bold"
+                style={{ color: "var(--quiz-title-color)" }}
+              >
+                {contest.name}
+              </div>
+              <div
+                className="text-sm"
+                style={{ color: "var(--quiz-subtitle-color)" }}
+              >
+                {contest.participants} people joined
+              </div>
+            </div>
+            {/* Progress Circle for hours left */}
+            <div className="flex-shrink-0 ml-4">
+              <HourProgressCircle hours={contest.timeleftinhours} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HourProgressCircle({ hours }: { hours: number }) {
+  // Normalize and color logic
+  let circleColor = "var(--progress-low)";
+  let textColor = "var(--progress-low)";
+
+  if (hours >= 24) {
+    circleColor = "var(--progress-high)"; // Green
+    textColor = "var(--progress-high)";
+  } else if (hours >= 20) {
+    circleColor = "var(--progress-medium)"; // Orange
+    textColor = "var(--progress-medium)";
+  } else {
+    circleColor = "var(--progress-low)"; // Purple
+    textColor = "var(--progress-low)";
+  }
+
+  // For the circle, treat max as 24h
+  const size = 52;
+  const strokeWidth = 4;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const percent = Math.max(0, Math.min(100, Math.round((hours / 24) * 100)));
+  const offset = circumference - (percent / 100) * circumference;
+
+  return (
+    <svg width={size} height={size} className="block transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="var(--progress-bg)"
+        strokeWidth={strokeWidth}
+        fill="none"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={circleColor}
+        strokeWidth={strokeWidth}
+        fill="none"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        style={{ transition: "stroke-dashoffset 0.6s ease-in-out" }}
+      />
+      <text
+        x="50%"
+        y="50%"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="14px"
+        fontWeight="600"
+        fill={textColor}
+        className="transform rotate-90"
+        style={{ transformOrigin: "center" }}
+      >
+        {hours}h
+      </text>
+    </svg>
+  );
+}


### PR DESCRIPTION

<img width="258" height="533" alt="image" src="https://github.com/user-attachments/assets/cdc82f64-a36d-4ed5-b8a6-b43b3c8c0ca3" />

<img width="258" height="533" alt="image" src="https://github.com/user-attachments/assets/dc1c971e-6b24-4d78-98c3-4a401f3d6e85" />

**Description:**  
- Added the `JoinedContests` component in joined-contests.tsx to visually display contests joined by the user.
- The UI matches the style of the unfinished quizzes section, showing contest name, number of participants, and a progress circle indicating hours left to start.
- Uses dummy data for preview; ready for dynamic integration.
- Ensures consistent design and user experience across contest-related components.

Let me know if you need the description tailored further!