### PR TITLE
Implement Dynamic Joined Contests UI with API Integration and Time Calculation

### DIFF
--- a/src/app/api/play/joinedContest/route.ts
+++ b/src/app/api/play/joinedContest/route.ts
@@ -45,8 +45,13 @@ export async function GET(req: Request) {
     // Calculate time left for each contest
     const timetobegincontest = joinedContest.map((item) => {
       const contest = item.contest;
-      const timeleftinhours =
-        (new Date(contest.startTime).getTime() - Date.now()) / (1000 * 60 * 60); // hours
+      const timeleftinhours = Math.max(
+        0,
+        Math.floor(
+          (new Date(contest.startTime).getTime() - Date.now()) /
+            (1000 * 60 * 60)
+        )
+      );
       return {
         ...contest,
         timeleftinhours,

--- a/src/app/api/play/joinedContest/route.ts
+++ b/src/app/api/play/joinedContest/route.ts
@@ -17,6 +17,9 @@ export async function GET(req: Request) {
   }
 
   const wallet = decoded.wallet;
+  if (!wallet) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   try {
     const joinedContest = await prisma.contestParticipant.findMany({
@@ -49,7 +52,7 @@ export async function GET(req: Request) {
         timeleftinhours,
       };
     });
-    return NextResponse.json(timetobegincontest)
+    return NextResponse.json(timetobegincontest);
   } catch (err) {
     console.error(err);
     return NextResponse.json(

--- a/src/app/api/play/joinedContest/route.ts
+++ b/src/app/api/play/joinedContest/route.ts
@@ -17,9 +17,6 @@ export async function GET(req: Request) {
   }
 
   const wallet = decoded.wallet;
-  if (!wallet) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
 
   try {
     const joinedContest = await prisma.contestParticipant.findMany({
@@ -52,7 +49,7 @@ export async function GET(req: Request) {
         timeleftinhours,
       };
     });
-    return NextResponse.json(timetobegincontest);
+    return NextResponse.json(timetobegincontest)
   } catch (err) {
     console.error(err);
     return NextResponse.json(

--- a/src/components/play/joined-contests.tsx
+++ b/src/components/play/joined-contests.tsx
@@ -29,21 +29,32 @@ export default function JoinedContests() {
       setError(null);
       try {
         const res = await fetch("/api/play/joinedContest");
-        const data = await res.json();
+        const isJson = res.headers
+          .get("content-type")
+          ?.includes("application/json");
+        const data = isJson ? await res.json().catch(() => null) : null;
         if (!res.ok) {
-          setError(data.error);
+          setError(
+            (data && (data.error || data.message)) ||
+              (res.status === 401
+                ? "Please log in to view joined contests"
+                : res.status === 500
+                ? "Internal Server Error"
+                : "Failed to fetch joined contests")
+          );
+          setJoinedInfo([]);
+          return;
         }
-        console.log(data);
         setJoinedInfo(Array.isArray(data) ? data : []);
       } catch (err) {
         console.error(err);
-        setError(error);
+        setError("Failed to fetch joined contests");
       } finally {
         setLoading(false);
       }
     };
     fetchUsersJoinedContests();
-  }, [address, isConnected, error]);
+  }, [address, isConnected]);
   if (error) {
     return <div className="text-destructive">{error}</div>;
   }

--- a/src/components/play/joined-contests.tsx
+++ b/src/components/play/joined-contests.tsx
@@ -1,38 +1,56 @@
 "use client";
 import Image from "next/image";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+import Spinner from "../ui/Spinner";
 
 interface JoinedContest {
   name: string;
-  participants: number;
+  startTime: string;
+  _count: {
+    participants: number;
+  };
   timeleftinhours: number;
 }
 
-// Dummy data for UI preview
-const joinedContests: JoinedContest[] = [
-  {
-    name: "DEX vs CEX",
-    participants: 158,
-    timeleftinhours: 12,
-  },
-  {
-    name: "Unstable Coin",
-    participants: 20,
-    timeleftinhours: 12,
-  },
-  {
-    name: "DEX vs CEX",
-    participants: 20,
-    timeleftinhours: 24,
-  },
-  {
-    name: "DEX vs CEX",
-    participants: 20,
-    timeleftinhours: 20,
-  },
-];
-
 export default function JoinedContests() {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [joinedInfo, setJoinedInfo] = useState<JoinedContest[]>([]);
+  const { address, isConnected } = useAccount();
+
+  useEffect(() => {
+    if (!address || !isConnected) {
+      setError("User Is Not Connected");
+      return;
+    }
+    const fetchUsersJoinedContests = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/play/joinedContest");
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error);
+        }
+        console.log(data);
+        setJoinedInfo(Array.isArray(data) ? data : []);
+      } catch (err) {
+        console.error(err);
+        setError(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchUsersJoinedContests();
+  }, [address, isConnected, error]);
+  if (error) {
+    return <div className="text-destructive">{error}</div>;
+  }
+  if (loading) {
+    return <Spinner />;
+  }
+
   return (
     <div className="px-6 mt-8 pb-24">
       <h3
@@ -42,47 +60,51 @@ export default function JoinedContests() {
         Contests you have joined
       </h3>
       <div className="space-y-4">
-        {joinedContests.map((contest, idx) => (
-          <div
-            key={idx}
-            className="flex items-center rounded-xl px-4 py-4 shadow-sm min-h-[80px]"
-            style={{
-              backgroundColor: "var(--quiz-card-bg)",
-              border: "1px solid var(--quiz-card-border)",
-            }}
-          >
-            {/* Left Icon */}
-            <div className="flex-shrink-0">
-              <Image
-                src="/cube1.svg"
-                alt="Contest Icon"
-                width={48}
-                height={48}
-                className="object-contain"
-                priority
-              />
-            </div>
-            {/* Contest Info */}
-            <div className="flex-1 ml-4">
-              <div
-                className="text-lg font-bold"
-                style={{ color: "var(--quiz-title-color)" }}
-              >
-                {contest.name}
+        {Array.isArray(joinedInfo) && joinedInfo.length > 0 ? (
+          joinedInfo.map((contest: JoinedContest, idx: number) => (
+            <div
+              key={idx}
+              className="flex items-center rounded-xl px-4 py-4 shadow-sm min-h-[80px]"
+              style={{
+                backgroundColor: "var(--quiz-card-bg)",
+                border: "1px solid var(--quiz-card-border)",
+              }}
+            >
+              {/* Left Icon */}
+              <div className="flex-shrink-0">
+                <Image
+                  src="/cube1.svg"
+                  alt="Contest Icon"
+                  width={48}
+                  height={48}
+                  className="object-contain"
+                  priority
+                />
               </div>
-              <div
-                className="text-sm"
-                style={{ color: "var(--quiz-subtitle-color)" }}
-              >
-                {contest.participants} people joined
+              {/* Contest Info */}
+              <div className="flex-1 ml-4">
+                <div
+                  className="text-lg font-bold"
+                  style={{ color: "var(--quiz-title-color)" }}
+                >
+                  {contest.name}
+                </div>
+                <div
+                  className="text-sm"
+                  style={{ color: "var(--quiz-subtitle-color)" }}
+                >
+                  {contest._count?.participants ?? 0} people joined
+                </div>
+              </div>
+              {/* Progress Circle for hours left */}
+              <div className="flex-shrink-0 ml-4">
+                <HourProgressCircle hours={contest.timeleftinhours} />
               </div>
             </div>
-            {/* Progress Circle for hours left */}
-            <div className="flex-shrink-0 ml-4">
-              <HourProgressCircle hours={contest.timeleftinhours} />
-            </div>
-          </div>
-        ))}
+          ))
+        ) : (
+          <div className="text-muted-foreground">No contests joined.</div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION

<img width="222" height="473" alt="image" src="https://github.com/user-attachments/assets/adfe671f-f226-4f5f-9eca-df3acb16e571" />


**PR Description:**  
This PR updates the joined contests component to fetch contest data dynamically from the backend, replacing static mock data. The UI now displays real contest names, participant counts, and calculates the time left for each contest based on backend data. The component handles loading and error states, and shows a message when no contests are joined. This improves the accuracy and user experience of the joined contests section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - View contests you’ve joined on the Play page, showing contest name, participant count, and a circular hours-left indicator.
  - Server endpoint powers wallet-personalized data and returns clear messages for missing/expired/unauthorized sessions.

- UI
  - Replaced “Unfinished Quizzes” with “Joined Contests.”
  - Added loading spinner, empty state (“No contests joined.”), and inline error messaging for failed fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->