### PR TITLE
Refactor: Remove Unused Statistics Model and Improve Contest Participant Seeding

### DIFF
--- a/prisma/migrations/20250903110741_remove_statistics/migration.sql
+++ b/prisma/migrations/20250903110741_remove_statistics/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `statisticsId` on the `QuizAttempt` table. All the data in the column will be lost.
+  - You are about to drop the `Statistics` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."QuizAttempt" DROP CONSTRAINT "QuizAttempt_statisticsId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."QuizAttempt" DROP COLUMN "statisticsId";
+
+-- DropTable
+DROP TABLE "public"."Statistics";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,27 +67,18 @@ model Rewards {
   userId              String?
 }
 
-model Statistics {
-  id        String        @id @default(uuid())
-  title     String
-  category  String
-  createdAt DateTime      @default(now())
-  attempts  QuizAttempt[]
-}
-
 model QuizAttempt {
-  id           String      @id @default(uuid())
-  user         user        @relation(fields: [userId], references: [id])
-  userId       String
-  quiz         Quiz        @relation(fields: [quizId], references: [id])
-  quizId       Int // MUST match Quiz.id type
-  score        Float
-  won          Boolean
-  createdAt    DateTime    @default(now())
-  statistics   Statistics? @relation(fields: [statisticsId], references: [id])
-  statisticsId String?
-  progress     Float       @default(0) // percentage completed (0-100)
-  isFinished   Boolean     @default(false) // true if quiz is completed
+  id         String   @id @default(uuid())
+  user       user     @relation(fields: [userId], references: [id])
+  userId     String
+  quiz       Quiz     @relation(fields: [quizId], references: [id])
+  quizId     Int // MUST match Quiz.id type
+  score      Float
+  won        Boolean
+  createdAt  DateTime @default(now())
+  // ...existing code...
+  progress   Float    @default(0) // percentage completed (0-100)
+  isFinished Boolean  @default(false) // true if quiz is completed
 }
 
 model ProfileStats {

--- a/prisma/seeder/mainSeeder.ts
+++ b/prisma/seeder/mainSeeder.ts
@@ -9,8 +9,10 @@ async function clearDatabase() {
   await prisma.profileStats.deleteMany({});
   await prisma.rewards.deleteMany({});
   await prisma.trophy.deleteMany({});
-  await prisma.statistics.deleteMany({});
+  // ...existing code...
   await prisma.question.deleteMany({});
+  await prisma.contestParticipant.deleteMany({});
+  await prisma.contest.deleteMany({});
   await prisma.quiz.deleteMany({});
   await prisma.user.deleteMany({});
 }


### PR DESCRIPTION


**PR Description:**  
- Removed the unused `Statistics` model from the Prisma schema and deleted its reference in the `QuizAttempt` model.
- Updated contest participant seeder logic to randomly assign each user 0–3 attempts per contest, creating a more realistic distribution of contest plays and participants.
- Fixed seeder and migration issues related to model removal and foreign key constraints.  
- Ensured database and seeders are aligned with current application requirements.