### PR TITLE
feat: add registrationEndTimeHours to Contest model and update seeder logic

### DIFF
--- a/prisma/migrations/20250904102450_add_reg_end_time_contest/migration.sql
+++ b/prisma/migrations/20250904102450_add_reg_end_time_contest/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Contest" ADD COLUMN     "registrationEndTime" TIMESTAMP(3);

--- a/prisma/migrations/20250904104716_add_reg_end_time_contest_integer/migration.sql
+++ b/prisma/migrations/20250904104716_add_reg_end_time_contest_integer/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `registrationEndTime` on the `Contest` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Contest" DROP COLUMN "registrationEndTime",
+ADD COLUMN     "registrationEndTimeHours" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,14 +103,15 @@ model TopCategory {
 }
 
 model Contest {
-  id           String               @id @default(uuid())
-  name         String
-  quiz         Quiz                 @relation(fields: [quizId], references: [id])
-  quizId       Int
-  startTime    DateTime
-  endTime      DateTime
-  participants ContestParticipant[]
-  createdAt    DateTime             @default(now())
+  id                       String               @id @default(uuid())
+  name                     String
+  quiz                     Quiz                 @relation(fields: [quizId], references: [id])
+  quizId                   Int
+  startTime                DateTime
+  endTime                  DateTime
+  registrationEndTimeHours Int?
+  participants             ContestParticipant[]
+  createdAt                DateTime             @default(now())
 }
 
 model ContestParticipant {

--- a/prisma/seeder/contestSeed.ts
+++ b/prisma/seeder/contestSeed.ts
@@ -10,19 +10,27 @@ export async function main(prisma: PrismaClient) {
   const contestData = quizzes.map((quiz, idx) => {
     // Randomly pick a time limit for each contest
     const timeLimit = timeLimits[Math.floor(Math.random() * timeLimits.length)];
-    // Start time: staggered by idx, some in future, some in past
-    const startOffset = ((idx % 4) - 2) * 3600 * 1000; // -2, -1, 0, 1 hours
-    const startTime = new Date(Date.now() + startOffset);
+    // Randomly pick hours to add to 5 days for startTime
+    const randomHours = Math.floor(Math.random() * 24) + 1; // 1 to 24 hours
+    const createdAt = new Date();
+    const startTime = new Date(
+      createdAt.getTime() + 5 * 24 * 3600 * 1000 + randomHours * 3600 * 1000
+    );
     const endTime = new Date(startTime.getTime() + timeLimit * 3600 * 1000);
+    // registrationEndTimeHours: random value between 1 and (hours between createdAt and startTime)
+    const maxRegHours = Math.floor(
+      (startTime.getTime() - createdAt.getTime()) / (3600 * 1000)
+    );
+    const registrationEndTimeHours =
+      Math.floor(Math.random() * maxRegHours) + 1;
     return {
       id: `contest-${quiz.id}-id`,
       name: quiz.title,
       quizId: quiz.id,
       startTime,
       endTime,
-      // Optionally, you can add timeLeftToStart and timeLeftToEnd for clarity
-      // timeLeftToStart: Math.max(0, startTime.getTime() - Date.now()),
-      // timeLeftToEnd: Math.max(0, endTime.getTime() - Date.now()),
+      createdAt,
+      registrationEndTimeHours,
     };
   });
   await prisma.contest.createMany({ data: contestData });


### PR DESCRIPTION


**Description:**  
- Updated the `Contest` model in `schema.prisma` to replace `registrationEndTime` (DateTime) with `registrationEndTimeHours` (Int) for flexible registration period management.
- Refactored the contest seeder to:
  - Set `createdAt` to the current time.
  - Set `startTime` to 5 days plus a random number of hours after creation.
  - Set `endTime` to a random duration after `startTime`.
  - Set `registrationEndTimeHours` to a random value between 1 and the total hours between creation and start.
- Removed all references to the old `registrationEndTime` field.
- Ensured the seeder and schema are consistent for contest creation and registration logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for a per-contest registration end time (in hours).
  - Added created date to contest data to enable clearer scheduling.

- Improvements
  - Demo data now uses realistic schedules: contests start ~5 days after creation with a random hour offset; registration window aligns with the start time.

- Chores
  - Updated database schema to replace the old registration end timestamp with an hours-based field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->