### PR TITLE
feat: Refactor ContestTab to use mock data and add progress circle for hours left

### DIFF
--- a/src/components/searchpage/ContestTab.tsx
+++ b/src/components/searchpage/ContestTab.tsx
@@ -1,77 +1,146 @@
-import { Card } from "@/components/ui/card";
+import React from "react";
+import Image from "next/image";
 
-export type Contest = {
-  id: string;
+type Contest = {
+  id: number;
   name: string;
-  prize: string;
-  entrants: number;
-  endsIn: string; // human readable, e.g., "2d 4h"
+  category: string;
+  registrationEndTime: string;
+  participantCount: number;
+  hoursLeft: number;
 };
 
-interface ContestTabProps {
-  contests?: Contest[];
-}
+const mockContests: Contest[] = [
+  {
+    id: 1,
+    name: "Math Mania",
+    category: "Math",
+    registrationEndTime: "2025-09-10T18:00:00Z",
+    participantCount: 120,
+    hoursLeft: 12,
+  },
+  {
+    id: 2,
+    name: "Science Sprint",
+    category: "Science",
+    registrationEndTime: "2025-09-12T20:00:00Z",
+    participantCount: 95,
+    hoursLeft: 22,
+  },
+  {
+    id: 3,
+    name: "History Hunt",
+    category: "History",
+    registrationEndTime: "2025-09-15T15:00:00Z",
+    participantCount: 60,
+    hoursLeft: 5,
+  },
+];
 
-export default function ContestTab({ contests }: ContestTabProps) {
-  const placeholder: Contest[] = [
-    {
-      id: "c1",
-      name: "Weekly Winners",
-      prize: "₹500",
-      entrants: 342,
-      endsIn: "2d 4h",
-    },
-    {
-      id: "c2",
-      name: "Rapid Fire Championship",
-      prize: "Trophy",
-      entrants: 128,
-      endsIn: "5d",
-    },
-    {
-      id: "c3",
-      name: "Monthly Marathon",
-      prize: "Amazon Voucher",
-      entrants: 860,
-      endsIn: "18d",
-    },
-  ];
-
-  // Use placeholder only when `contests` is nullish; keep [] as an explicit empty state.
-  const list = contests ?? placeholder;
+export default function ContestTab() {
   return (
     <div className="mt-4 px-4">
-      <div className="flex flex-col gap-4 w-full max-w-md mx-auto">
-        <h2 className="text-xl font-semibold">Live Contests</h2>
-        <div className="grid gap-3">
-          {list.map((c) => (
-            <Card
-              key={c.id}
-              className="px-4 py-6 rounded-md border-0 flex flex-row items-center justify-between shadow-sm"
-              aria-label={`Contest ${c.name}`}
-            >
-              {/* Contest Info */}
-              <div>
-                <div className="font-semibold">{c.name}</div>
-                <div className="text-sm text-muted-foreground">
-                  {c.entrants} entrants • ends in {c.endsIn}
-                </div>
+      <div className="flex flex-col gap-4 w-full min-w-[370px] mx-auto">
+        {mockContests.map((contest) => (
+          <div
+            key={contest.id}
+            className="w-full rounded-3xl px-5 py-4 shadow-sm bg-white border border-gray-100"
+          >
+            <div className="flex items-center w-full gap-4">
+              {/* Icon */}
+              <div className="flex-shrink-0">
+                <Image
+                  src="/cube1.svg"
+                  alt="Contest Icon"
+                  width={48}
+                  height={48}
+                  className="object-contain"
+                  priority
+                />
               </div>
 
-              {/* Prize and CTA */}
-              <div className="text-right flex flex-col items-end justify-center">
-                <div className="font-medium">{c.prize}</div>
-                <button
-                  type="button"
-                  className="text-xs text-muted-foreground mt-1 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background"
-                >
-                  Join now
-                </button>
+              {/* Title + Description */}
+              <div className="flex-1 min-w-0">
+                <p className="text-lg sm:text-2xl font-semibold text-gray-900">
+                  {contest.name}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {contest.participantCount} participants
+                </p>
               </div>
-            </Card>
-          ))}
-        </div>
+
+              {/* Registration/Hours Left */}
+              <div className="flex flex-col items-center font-semibold flex-shrink-0">
+                <HourProgressCircle hours={contest.hoursLeft} />
+                <span className="text-sm font-normal text-gray-500">
+                  Hours left
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
+  );
+}
+
+function HourProgressCircle({ hours }: { hours: number }) {
+  let circleColor = "var(--progress-low)";
+  let textColor = "var(--progress-low)";
+
+  if (hours >= 24) {
+    circleColor = "var(--progress-high)";
+    textColor = "var(--progress-high)";
+  } else if (hours >= 20) {
+    circleColor = "var(--progress-medium)";
+    textColor = "var(--progress-medium)";
+  } else {
+    circleColor = "var(--progress-low)";
+    textColor = "var(--progress-low)";
+  }
+
+  const size = 48;
+  const strokeWidth = 4;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const percent = Math.max(0, Math.min(100, Math.round((hours / 24) * 100)));
+  const offset = circumference - (percent / 100) * circumference;
+
+  return (
+    <svg width={size} height={size} className="block transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="var(--progress-bg)"
+        strokeWidth={strokeWidth}
+        fill="none"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={circleColor}
+        strokeWidth={strokeWidth}
+        fill="none"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        style={{ transition: "stroke-dashoffset 0.6s ease-in-out" }}
+      />
+      <text
+        x="50%"
+        y="50%"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="14px"
+        fontWeight="600"
+        fill={textColor}
+        className="transform rotate-90"
+        style={{ transformOrigin: "center" }}
+      >
+        {hours}h
+      </text>
+    </svg>
   );
 }


### PR DESCRIPTION

<img width="218" height="465" alt="image" src="https://github.com/user-attachments/assets/55cfb698-9c7c-403e-b3e4-be3c7c9e96e9" />

**PR Description:**  
This PR refactors the `ContestTab` component to display contest cards using mock data instead of fetching from an API. The layout is improved for consistency and responsiveness, and a circular progress indicator is added to visually represent the hours left for contest registration. The code is cleaned up to remove duplicate functions and ensure proper component structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an hour-based progress circle showing time left for each contest.
  * Displayed participant counts alongside contest names.
* **UI/UX**
  * Redesigned Contest tab from a grid of cards to a clean vertical list with rounded blocks.
  * Added consistent icons and a right-aligned hours-left indicator for quicker scanning.
* **Chores**
  * Contest list now appears populated by default within the tab for easier browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->