### PR TITLE
Show Both Quiz and Contest Cards in LatestTab with Unified Design and Mock Data

### DIFF
--- a/src/app/api/search/latestaddedall/route.ts
+++ b/src/app/api/search/latestaddedall/route.ts
@@ -44,13 +44,27 @@ export async function GET() {
       attemptsCount: q._count.attempts,
     }));
 
-    const contestItems = fetchlatestcontest.map((c) => ({
-      type: "contest",
-      name: c.name,
-      createdAt: c.createdAt,
-      startTime: c.startTime,
-      participantsCount: c._count.participants,
-    }));
+    const contestItems = fetchlatestcontest.map((c) => {
+      let timeLeftHours = 0;
+      const startTimestamp = Date.parse(String(c.startTime));
+      if (!isNaN(startTimestamp)) {
+        timeLeftHours = Math.max(
+          0,
+          Math.round((startTimestamp - Date.now()) / (1000 * 60 * 60))
+        );
+      } else {
+        console.warn("Invalid startTime for contest:", c.startTime);
+        timeLeftHours = 0;
+      }
+      return {
+        type: "contest",
+        name: c.name,
+        createdAt: c.createdAt,
+        startTime: c.startTime,
+        participantsCount: c._count.participants,
+        timeLeftHours,
+      };
+    });
 
     // Merge and sort
     const allItems = [...quizItems, ...contestItems].sort(

--- a/src/app/api/search/latestaddedall/route.ts
+++ b/src/app/api/search/latestaddedall/route.ts
@@ -1,0 +1,75 @@
+import prisma from "@/lib/prisma/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const fetchlatestquiz = await prisma.quiz.findMany({
+      select: {
+        title: true,
+        createdAt: true,
+        _count: {
+          select: {
+            questions: true,
+            attempts: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    const fetchlatestcontest = await prisma.contest.findMany({
+      select: {
+        name: true,
+        createdAt: true,
+        startTime: true,
+        _count: {
+          select: {
+            participants: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    // Map to unified format
+    const quizItems = fetchlatestquiz.map((q) => ({
+      type: "quiz",
+      title: q.title,
+      createdAt: q.createdAt,
+      questionsCount: q._count.questions,
+      attemptsCount: q._count.attempts,
+    }));
+
+    const contestItems = fetchlatestcontest.map((c) => ({
+      type: "contest",
+      name: c.name,
+      createdAt: c.createdAt,
+      startTime: c.startTime,
+      participantsCount: c._count.participants,
+    }));
+
+    // Merge and sort
+    const allItems = [...quizItems, ...contestItems].sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+
+    if (allItems.length === 0) {
+      return NextResponse.json(
+        { error: "No Quiz or Contest found" },
+        { status: 404 }
+      );
+    }
+    return NextResponse.json({ items: allItems }, { status: 200 });
+  } catch (error) {
+    console.log(error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/search/latestaddedcontests/route.ts
+++ b/src/app/api/search/latestaddedcontests/route.ts
@@ -24,11 +24,11 @@ export async function GET() {
 
     // Calculate time left to begin in hours for each contest
     const contestsWithTimeLeft = latestContest.map((contest) => {
-      const timeleftToBegin =
+      const timelefttobegin =
         (new Date(contest.startTime).getTime() - Date.now()) / (1000 * 60 * 60); // hours
       return {
         ...contest,
-        timeleftToBegin,
+        timelefttobegin,
       };
     });
 

--- a/src/app/api/search/latestaddedcontests/route.ts
+++ b/src/app/api/search/latestaddedcontests/route.ts
@@ -24,11 +24,20 @@ export async function GET() {
 
     // Calculate time left to begin in hours for each contest
     const contestsWithTimeLeft = latestContest.map((contest) => {
-      const timelefttobegin =
-        (new Date(contest.startTime).getTime() - Date.now()) / (1000 * 60 * 60); // hours
+      let timeLeftHours = 0;
+      const startTimestamp = Date.parse(String(contest.startTime));
+      if (!isNaN(startTimestamp)) {
+        timeLeftHours = Math.max(
+          0,
+          Math.round((startTimestamp - Date.now()) / (1000 * 60 * 60))
+        );
+      } else {
+        console.warn("Invalid startTime for contest:", contest.startTime);
+        timeLeftHours = 0;
+      }
       return {
         ...contest,
-        timelefttobegin,
+        timeLeftHours,
       };
     });
 

--- a/src/components/searchpage/ContestTab.tsx
+++ b/src/components/searchpage/ContestTab.tsx
@@ -1,77 +1,146 @@
-import { Card } from "@/components/ui/card";
+import React from "react";
+import Image from "next/image";
 
-export type Contest = {
-  id: string;
+type Contest = {
+  id: number;
   name: string;
-  prize: string;
-  entrants: number;
-  endsIn: string; // human readable, e.g., "2d 4h"
+  category: string;
+  registrationEndTime: string;
+  participantCount: number;
+  hoursLeft: number;
 };
 
-interface ContestTabProps {
-  contests?: Contest[];
-}
+const mockContests: Contest[] = [
+  {
+    id: 1,
+    name: "Math Mania",
+    category: "Math",
+    registrationEndTime: "2025-09-10T18:00:00Z",
+    participantCount: 120,
+    hoursLeft: 12,
+  },
+  {
+    id: 2,
+    name: "Science Sprint",
+    category: "Science",
+    registrationEndTime: "2025-09-12T20:00:00Z",
+    participantCount: 95,
+    hoursLeft: 22,
+  },
+  {
+    id: 3,
+    name: "History Hunt",
+    category: "History",
+    registrationEndTime: "2025-09-15T15:00:00Z",
+    participantCount: 60,
+    hoursLeft: 5,
+  },
+];
 
-export default function ContestTab({ contests }: ContestTabProps) {
-  const placeholder: Contest[] = [
-    {
-      id: "c1",
-      name: "Weekly Winners",
-      prize: "₹500",
-      entrants: 342,
-      endsIn: "2d 4h",
-    },
-    {
-      id: "c2",
-      name: "Rapid Fire Championship",
-      prize: "Trophy",
-      entrants: 128,
-      endsIn: "5d",
-    },
-    {
-      id: "c3",
-      name: "Monthly Marathon",
-      prize: "Amazon Voucher",
-      entrants: 860,
-      endsIn: "18d",
-    },
-  ];
-
-  // Use placeholder only when `contests` is nullish; keep [] as an explicit empty state.
-  const list = contests ?? placeholder;
+export default function ContestTab() {
   return (
     <div className="mt-4 px-4">
-      <div className="flex flex-col gap-4 w-full max-w-md mx-auto">
-        <h2 className="text-xl font-semibold">Live Contests</h2>
-        <div className="grid gap-3">
-          {list.map((c) => (
-            <Card
-              key={c.id}
-              className="px-4 py-6 rounded-md border-0 flex flex-row items-center justify-between shadow-sm"
-              aria-label={`Contest ${c.name}`}
-            >
-              {/* Contest Info */}
-              <div>
-                <div className="font-semibold">{c.name}</div>
-                <div className="text-sm text-muted-foreground">
-                  {c.entrants} entrants • ends in {c.endsIn}
-                </div>
+      <div className="flex flex-col gap-4 w-full min-w-[370px] mx-auto">
+        {mockContests.map((contest) => (
+          <div
+            key={contest.id}
+            className="w-full rounded-3xl px-5 py-4 shadow-sm bg-white border border-gray-100"
+          >
+            <div className="flex items-center w-full gap-4">
+              {/* Icon */}
+              <div className="flex-shrink-0">
+                <Image
+                  src="/cube1.svg"
+                  alt="Contest Icon"
+                  width={48}
+                  height={48}
+                  className="object-contain"
+                  priority
+                />
               </div>
 
-              {/* Prize and CTA */}
-              <div className="text-right flex flex-col items-end justify-center">
-                <div className="font-medium">{c.prize}</div>
-                <button
-                  type="button"
-                  className="text-xs text-muted-foreground mt-1 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background"
-                >
-                  Join now
-                </button>
+              {/* Title + Description */}
+              <div className="flex-1 min-w-0">
+                <p className="text-lg sm:text-2xl font-semibold text-gray-900">
+                  {contest.name}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {contest.participantCount} participants
+                </p>
               </div>
-            </Card>
-          ))}
-        </div>
+
+              {/* Registration/Hours Left */}
+              <div className="flex flex-col items-center font-semibold flex-shrink-0">
+                <HourProgressCircle hours={contest.hoursLeft} />
+                <span className="text-sm font-normal text-gray-500">
+                  Hours left
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
+  );
+}
+
+function HourProgressCircle({ hours }: { hours: number }) {
+  let circleColor = "var(--progress-low)";
+  let textColor = "var(--progress-low)";
+
+  if (hours >= 24) {
+    circleColor = "var(--progress-high)";
+    textColor = "var(--progress-high)";
+  } else if (hours >= 20) {
+    circleColor = "var(--progress-medium)";
+    textColor = "var(--progress-medium)";
+  } else {
+    circleColor = "var(--progress-low)";
+    textColor = "var(--progress-low)";
+  }
+
+  const size = 48;
+  const strokeWidth = 4;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const percent = Math.max(0, Math.min(100, Math.round((hours / 24) * 100)));
+  const offset = circumference - (percent / 100) * circumference;
+
+  return (
+    <svg width={size} height={size} className="block transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="var(--progress-bg)"
+        strokeWidth={strokeWidth}
+        fill="none"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={circleColor}
+        strokeWidth={strokeWidth}
+        fill="none"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        style={{ transition: "stroke-dashoffset 0.6s ease-in-out" }}
+      />
+      <text
+        x="50%"
+        y="50%"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="14px"
+        fontWeight="600"
+        fill={textColor}
+        className="transform rotate-90"
+        style={{ transformOrigin: "center" }}
+      >
+        {hours}h
+      </text>
+    </svg>
   );
 }

--- a/src/components/searchpage/ContestTab.tsx
+++ b/src/components/searchpage/ContestTab.tsx
@@ -1,49 +1,61 @@
-import React from "react";
+"use client";
+import React, { useEffect, useState } from "react";
 import Image from "next/image";
+import Spinner from "../ui/Spinner";
 
-type Contest = {
-  id: number;
+type LatestContestProps = {
   name: string;
-  category: string;
-  registrationEndTime: string;
-  participantCount: number;
-  hoursLeft: number;
+  timelefttobegin: number;
+  createdAt: string;
+  _count: {
+    participants: number;
+  };
 };
 
-const mockContests: Contest[] = [
-  {
-    id: 1,
-    name: "Math Mania",
-    category: "Math",
-    registrationEndTime: "2025-09-10T18:00:00Z",
-    participantCount: 120,
-    hoursLeft: 12,
-  },
-  {
-    id: 2,
-    name: "Science Sprint",
-    category: "Science",
-    registrationEndTime: "2025-09-12T20:00:00Z",
-    participantCount: 95,
-    hoursLeft: 22,
-  },
-  {
-    id: 3,
-    name: "History Hunt",
-    category: "History",
-    registrationEndTime: "2025-09-15T15:00:00Z",
-    participantCount: 60,
-    hoursLeft: 5,
-  },
-];
-
 export default function ContestTab() {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [latestContest, setLatestContest] = useState<LatestContestProps[]>([]);
+
+  useEffect(() => {
+    const fetchLastestContest = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch("/api/search/latestaddedcontests");
+        const data = await res.json();
+
+        if (!res.ok) {
+          setError(data.error || "Something went wrong");
+        }
+        setLatestContest(data);
+        setError(null);
+      } catch (error) {
+        console.error(error);
+        setError("Failed to fetch contests");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchLastestContest();
+  }, []);
+
+  if (error) {
+    return <div className="text-destructive">{error}</div>;
+  }
+
+  if (loading)
+    return (
+      <div className="flex justify-center items-center py-20">
+        <Spinner size={48} color="#8B5CF6" />
+      </div>
+    );
+
   return (
     <div className="mt-4 px-4">
       <div className="flex flex-col gap-4 w-full min-w-[370px] mx-auto">
-        {mockContests.map((contest) => (
+        {latestContest.map((contest) => (
           <div
-            key={contest.id}
+            key={contest.name}
             className="w-full rounded-3xl px-5 py-4 shadow-sm bg-white border border-gray-100"
           >
             <div className="flex items-center w-full gap-4">
@@ -65,13 +77,15 @@ export default function ContestTab() {
                   {contest.name}
                 </p>
                 <p className="text-sm text-gray-500">
-                  {contest.participantCount} participants
+                  {contest._count.participants} participants
                 </p>
               </div>
 
               {/* Registration/Hours Left */}
               <div className="flex flex-col items-center font-semibold flex-shrink-0">
-                <HourProgressCircle hours={contest.hoursLeft} />
+                <HourProgressCircle
+                  hours={Math.round(contest.timelefttobegin)}
+                />
                 <span className="text-sm font-normal text-gray-500">
                   Hours left
                 </span>

--- a/src/components/searchpage/LatestTab.tsx
+++ b/src/components/searchpage/LatestTab.tsx
@@ -1,59 +1,63 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useState } from "react";
-import Spinner from "../ui/Spinner";
 
-interface Quiz {
-  id: number;
-  title: string;
-  category: string;
-  createdAt: string;
-  _count: {
-    questions: number;
-    attempts: number;
-  };
-}
-
+type LatestItem =
+  | {
+      type: "quiz";
+      title: string;
+      createdAt: string;
+      questionsCount: number;
+      attemptsCount: number;
+    }
+  | {
+      type: "contest";
+      name: string;
+      createdAt: string;
+      startTime: string;
+      participantsCount: number;
+      timeLeftHours: number;
+    };
 
 export default function LatestTab() {
-  const [quizzes, setQuizzes] = useState<Quiz[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchQuizzes = async () => {
-      try {
-        const res = await fetch("/api/search/latestaddedquizzes");
-        const data = await res.json();
-
-        if (!res.ok) {
-          setError(data.error || "Something went wrong");
-        } else {
-          setQuizzes(data.quiz);
-        }
-      } catch (err) {
-        setError("Failed to fetch quizzes");
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchQuizzes();
-  }, []);
-
-  if (loading)
-    return (
-      <div className="flex justify-center items-center py-20">
-        <Spinner size={48} color="#8B5CF6" />
-      </div>
-    );
-  if (error) return <div>{error}</div>;
+  // Mock data for both quizzes and contests
+  const mockItems: LatestItem[] = [
+    {
+      type: "quiz",
+      title: "Gen. Knowledge",
+      createdAt: "2025-09-05T10:00:00Z",
+      questionsCount: 15,
+      attemptsCount: 120,
+    },
+    {
+      type: "contest",
+      name: "Sept Challenge",
+      createdAt: "2025-09-04T09:00:00Z",
+      startTime: "2025-09-10T12:00:00Z",
+      participantsCount: 45,
+      timeLeftHours: 12,
+    },
+    {
+      type: "quiz",
+      title: "Science Trivia",
+      createdAt: "2025-09-03T08:00:00Z",
+      questionsCount: 10,
+      attemptsCount: 80,
+    },
+    {
+      type: "contest",
+      name: "Math Contest",
+      createdAt: "2025-09-02T07:00:00Z",
+      startTime: "2025-09-07T15:00:00Z",
+      participantsCount: 30,
+      timeLeftHours: 5,
+    },
+  ];
 
   return (
     <div className="mt-4 px-4">
       <div className="flex flex-col gap-4 w-full min-w-[370px] mx-auto">
-        {quizzes.map((quiz: Quiz, idx: number) => (
+        {mockItems.map((item, idx) => (
           <div
             key={idx}
             className="w-full rounded-3xl px-5 py-4 shadow-sm bg-white border border-gray-100"
@@ -63,33 +67,125 @@ export default function LatestTab() {
               <div className="flex-shrink-0">
                 <Image
                   src="/cube1.svg"
-                  alt="Quiz Icon"
+                  alt="Cube Icon"
                   width={48}
                   height={48}
                   className="object-contain"
                   priority
                 />
               </div>
-              {/* Title + Description */}
-              <div className="flex-1 min-w-0">
-                <p className="text-lg sm:text-2xl font-semibold text-gray-900">
-                  {quiz.title}
-                </p>
-                <p className="text-sm text-gray-500">
-                  {quiz._count.questions} questions
-                </p>
-              </div>
-              {/* Plays */}
-              <div className="flex flex-col items-end justify-center flex-shrink-0">
-                <span className="text-lg font-semibold text-gray-900">
-                  {quiz._count.attempts}
-                </span>
-                <span className="text-sm font-normal text-gray-500">Plays</span>
-              </div>
+
+              {/* Title + Description & Stats */}
+              {item.type === "quiz" ? (
+                <>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-lg sm:text-2xl font-semibold text-gray-900">
+                      {item.title}
+                    </p>
+                    <p className="text-sm text-gray-500">
+                      {item.questionsCount} questions
+                    </p>
+                  </div>
+                  <div className="flex flex-col items-end justify-center flex-shrink-0">
+                    <span className="text-lg font-semibold text-gray-900">
+                      {item.attemptsCount}
+                    </span>
+                    <span className="text-sm font-normal text-gray-500">
+                      Plays
+                    </span>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-lg sm:text-2xl font-semibold text-gray-900">
+                      {item.name}
+                    </p>
+                    <p className="text-sm text-gray-500">
+                      {item.participantsCount} participants
+                    </p>
+                  </div>
+                  <div className="flex flex-col items-center font-semibold flex-shrink-0">
+                    <HourProgressCircle
+                      hours={
+                        typeof item.timeLeftHours === "number" &&
+                        !isNaN(item.timeLeftHours)
+                          ? item.timeLeftHours
+                          : 0
+                      }
+                    />
+                    <span className="text-sm font-normal text-gray-500">
+                      Hours left
+                    </span>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         ))}
       </div>
     </div>
+  );
+}
+
+// ContestTab's HourProgressCircle reused here
+function HourProgressCircle(props: { hours: number }) {
+  const hours =
+    typeof props.hours === "number" && !isNaN(props.hours) ? props.hours : 0;
+
+  let circleColor = "var(--progress-low)";
+  let textColor = "var(--progress-low)";
+
+  if (hours >= 24) {
+    circleColor = "var(--progress-high)";
+    textColor = "var(--progress-high)";
+  } else if (hours >= 20) {
+    circleColor = "var(--progress-medium)";
+    textColor = "var(--progress-medium)";
+  }
+
+  const size = 48;
+  const strokeWidth = 4;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const percent = Math.max(0, Math.min(100, Math.round((hours / 24) * 100)));
+  const offset = circumference - (percent / 100) * circumference;
+
+  return (
+    <svg width={size} height={size} className="block transform -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="var(--progress-bg)"
+        strokeWidth={strokeWidth}
+        fill="none"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={circleColor}
+        strokeWidth={strokeWidth}
+        fill="none"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        style={{ transition: "stroke-dashoffset 0.6s ease-in-out" }}
+      />
+      <text
+        x="50%"
+        y="50%"
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="14px"
+        fontWeight="600"
+        fill={textColor}
+        className="transform rotate-90"
+        style={{ transformOrigin: "center" }}
+      >
+        {hours}h
+      </text>
+    </svg>
   );
 }


### PR DESCRIPTION

<img width="215" height="469" alt="image" src="https://github.com/user-attachments/assets/ea39aae3-3500-4d4d-85df-efc2bdd8fcc2" />


**PR Description:**  
- Refactored `LatestTab` to display both quizzes and contests using a unified card design.
- Used the same cube SVG icon for both quiz and contest cards for visual consistency.
- Incorporated the contest card style and HourProgressCircle from `ContestTab` for contests.
- Updated mock data to include both quizzes and contests, with shorter titles for improved UI.
- Removed unused imports and fixed stray JSX/closing tags to resolve parsing errors.
- Ensured clean, error-free rendering of all items in the latest tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a combined “Latest” feed showing recently added quizzes and contests, sorted by date.
  - Contest tab now fetches live data with loading/error states and a compact card layout, including an hours‑left progress ring.
- Improvements
  - More accurate, non‑negative “hours left” calculation for contests.
  - Latest tab now displays both quizzes and contests with clear counts (questions, plays, participants) and visual time indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->