### PR TITLE
feat: Show user's most recent quiz or contest with unified API and widget logic

### DIFF
--- a/src/app/api/dashboard/recentquizorcontest/route.ts
+++ b/src/app/api/dashboard/recentquizorcontest/route.ts
@@ -39,6 +39,7 @@ export async function GET(req: Request) {
       },
       select: {
         quizId: true,
+        createdAt: true,
         quiz: {
           select: {
             title: true,
@@ -46,7 +47,34 @@ export async function GET(req: Request) {
         },
       },
     });
-    return NextResponse.json({ recentquiz });
+    const recentContest = await prisma.contestParticipant.findFirst({
+      where: {
+        userId: username.id
+      },
+      orderBy: {
+        joinedAt: "desc"
+      },
+      select: {
+        joinedAt:true,
+        contest: {
+          select: {
+            name: true,
+          }
+        }
+      }
+    });
+
+    const quizTime = recentquiz?.createdAt ? new Date(recentquiz.createdAt).getTime() : 0;
+    const contestTime = recentContest?.joinedAt ? new Date(recentContest.joinedAt).getTime() : 0;
+
+    let result;
+    if (quizTime >= contestTime) {
+      result = recentquiz;
+    } else {
+      result = recentContest;
+    }
+
+    return NextResponse.json({ result });
   } catch {
     return NextResponse.json(
       { error: "Internal Server Error" },

--- a/src/components/dashboard/RecentQuizWidget.tsx
+++ b/src/components/dashboard/RecentQuizWidget.tsx
@@ -37,7 +37,10 @@ export default function RecentQuizWidget({
   //RecentQuizInformation
   const { address, isConnected } = useAccount();
   const [error, setError] = useState<string | null>(null);
-  type RecentData = { quiz?: { title: string }; contest?: { name: string } } | null;
+  type RecentData = {
+    quiz?: { title: string };
+    contest?: { name: string };
+  } | null;
   const [recent, setRecent] = useState<RecentData>(null);
   const [number, setNumber] = useState<RecentQuizScoreProps | null>(null);
   const [token, setToken] = useState<string | null>(() => {
@@ -78,12 +81,7 @@ export default function RecentQuizWidget({
         return;
       }
       try {
-        const res = await fetch(`/api/dashboard/recentquizorcontest`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-        });
+        const res = await fetch(`/api/dashboard/recentquizorcontest`);
         const data = await res.json();
         if (!res.ok) {
           setError(data.error || "Internal Server Error");
@@ -153,11 +151,7 @@ export default function RecentQuizWidget({
           </div>
           <div className="flex-shrink-0">
             <CircularProgress
-              value={
-                recent?.quiz && typeof number?.score === "number"
-                  ? number.score
-                  : 0
-              }
+              value={recent?.quiz ? progress : 0}
               size={64}
               className="text-white"
             />

--- a/src/components/dashboard/RecentQuizWidget.tsx
+++ b/src/components/dashboard/RecentQuizWidget.tsx
@@ -37,10 +37,10 @@ export default function RecentQuizWidget({
   //RecentQuizInformation
   const { address, isConnected } = useAccount();
   const [error, setError] = useState<string | null>(null);
-  const [info, setInfo] = useState<RecentQuizProps | null>(null);
+  type RecentData = { quiz?: { title: string }; contest?: { name: string } } | null;
+  const [recent, setRecent] = useState<RecentData>(null);
   const [number, setNumber] = useState<RecentQuizScoreProps | null>(null);
   const [token, setToken] = useState<string | null>(() => {
-    // Initialize token from localStorage if available
     if (typeof window !== "undefined") {
       return localStorage.getItem("jwtToken");
     }
@@ -64,58 +64,41 @@ export default function RecentQuizWidget({
   }, [token]);
 
   useEffect(() => {
-    const fetchrecentquizinfo = async () => {
+    const fetchRecent = async () => {
       if (!isConnected || !address) {
         setError("Can't find user");
-        setInfo(null);
+        setRecent(null);
         setNumber(null);
         return;
       }
       if (!token) {
         setError("User not logged in");
-        setInfo(null);
+        setRecent(null);
         setNumber(null);
         return;
       }
       try {
-        const [resTitle, resScore] = await Promise.all([
-          fetch(`/api/dashboard/recentquiz`, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
-            },
-          }),
-          fetch(`/api/dashboard/recentquizscore`, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
-            },
-          }),
-        ]);
-        const [dataTitle, dataScore] = await Promise.all([
-          resTitle.json(),
-          resScore.json(),
-        ]);
-        let errorMsg = null;
-        console.log(dataTitle, dataScore);
-        if (!resTitle.ok && !resScore.ok) {
-          errorMsg =
-            dataTitle.error || dataScore.error || "Internal Server Error";
-          setInfo(null);
-          setNumber(null);
+        const res = await fetch(`/api/dashboard/recentquizorcontest`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error || "Internal Server Error");
+          setRecent(null);
         } else {
-          setInfo(resTitle.ok ? dataTitle.recentquiz : null);
-          setNumber(resScore.ok ? dataScore.recentquiz : null);
+          setRecent(data.result || null);
+          setError(null);
         }
-        setError(errorMsg);
       } catch (error) {
         console.error(error);
         setError("Internal Server Error");
-        setInfo(null);
-        setNumber(null);
+        setRecent(null);
       }
     };
-    fetchrecentquizinfo();
+    fetchRecent();
   }, [address, isConnected, token]);
 
   return (
@@ -130,7 +113,13 @@ export default function RecentQuizWidget({
       onClick={onClick}
       role="button"
       tabIndex={0}
-      aria-label={`Continue quiz: ${title}, ${progress}% complete`}
+      aria-label={
+        recent?.quiz
+          ? `Continue quiz: ${recent.quiz.title}, ${progress}% complete`
+          : recent?.contest
+          ? `View contest: ${recent.contest.name}`
+          : `No recent activity`
+      }
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
@@ -142,26 +131,33 @@ export default function RecentQuizWidget({
       <div className="absolute inset-0 bg-gradient-to-br from-violet-900/20 to-slate-800/10 pointer-events-none" />
 
       <div className="relative px-6">
-        {/* Content - Header and Quiz title on left, Progress on right */}
         <div className="flex items-center justify-between gap-4">
-          {/* Left side - Header and Quiz title together */}
           <div className="flex-1 min-w-0">
             <h3 className="text-md font-medium text-white uppercase tracking-wide mb-4">
-              Recent Quiz
+              {recent?.quiz
+                ? "Recent Quiz"
+                : recent?.contest
+                ? "Recent Contest"
+                : "Recent Activity"}
             </h3>
             <h4 className="text-lg font-semibold text-white leading-tight">
               {error
                 ? error
-                : info?.quiz?.title
-                ? info.quiz.title
-                : "No Recent Quiz"}
+                : recent?.quiz?.title
+                ? recent.quiz.title
+                : recent?.contest?.name
+                ? recent.contest.name
+                : "No Recent Activity"}
             </h4>
+            {/* No need to print joined/attempted time */}
           </div>
-
-          {/* Right side - Circular progress */}
           <div className="flex-shrink-0">
             <CircularProgress
-              value={typeof number?.score === "number" ? number.score : 0}
+              value={
+                recent?.quiz && typeof number?.score === "number"
+                  ? number.score
+                  : 0
+              }
               size={64}
               className="text-white"
             />


### PR DESCRIPTION

<img width="152" height="73" alt="image" src="https://github.com/user-attachments/assets/77b2e4f7-7ab9-418d-9ae2-9c5f889f14b4" />
<img width="139" height="82" alt="image" src="https://github.com/user-attachments/assets/fa819898-b32e-4654-b0c2-a9334704ec42" />


**Description:**  
- Adds API logic to retrieve and compare user's latest quiz attempt and contest participation, returning the most recent activity.
- Refactors `RecentQuizWidget` to seamlessly display either a recent quiz or contest, with clear differentiation and error handling.
- Removes redundant time details for a cleaner interface.
- Ensures consistent, robust user experience for recent activity display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard widget now highlights your most recent activity (choosing between quiz or contest) with adaptive header, title, and aria-labels.
  * Unified fallback displays “No Recent Activity” when applicable.

* **Bug Fixes**
  * Progress indicator shows a score only for quizzes, avoiding misleading values.
  * Improved error handling with clearer messages and safe fallbacks.
  * More reliable session updates via token synchronization.

* **Chores**
  * Consolidated multiple API calls into a single request for faster, more consistent loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->