### PR TITLE
feat: implement play page as a server component

### DIFF
--- a/src/app/play/HeaderSectionClient.tsx
+++ b/src/app/play/HeaderSectionClient.tsx
@@ -1,0 +1,21 @@
+"use client";
+import WelcomeHeader from "@/components/dashboard/WelcomeHeader";
+import BalanceCard from "@/components/dashboard/BalanceCard";
+import { useUser } from "@/context/userContext";
+
+/**
+ * Minimal client component: reads user context and renders the header row.
+ * Keeps the main page as a server component.
+ */
+export default function HeaderSectionClient() {
+  const { username, balance } = useUser();
+
+  return (
+    <div className="px-6 pt-12 pb-8">
+      <div className="flex items-start justify-between gap-4">
+        <WelcomeHeader name={username ?? undefined} />
+        <BalanceCard amount={balance ?? 0} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -1,12 +1,8 @@
-"use client";
-import WelcomeHeader from "@/components/dashboard/WelcomeHeader";
-import BalanceCard from "@/components/dashboard/BalanceCard";
 import PlayToday from "@/components/play/playToday";
-import { useUser } from "@/context/userContext";
 import JoinedContests from "@/components/play/joined-contests";
+import HeaderSectionClient from "./HeaderSectionClient";
 
 function PlayPage() {
-  const { username, balance } = useUser();
   return (
     <main
       className="min-h-screen relative overflow-x-hidden"
@@ -21,13 +17,8 @@ function PlayPage() {
 
       {/* Content */}
       <div className="relative z-10 pb-[calc(72px+env(safe-area-inset-bottom))]">
-        {/* Header Section with Welcome and Balance */}
-        <div className="px-6 pt-12 pb-8">
-          <div className="flex items-start justify-between gap-4">
-            <WelcomeHeader name={username ?? undefined} />
-            <BalanceCard amount={balance ?? 0} />
-          </div>
-        </div>
+        {/* Header Section with Welcome and Balance (client) */}
+        <HeaderSectionClient />
 
         {/* Main Card Container for PlayToday and UnfinishedQuizzesSection */}
         <div className="bg-card rounded-t-2xl w-full mx-0 pt-6 pb-8 flex flex-col min-h-[calc(100vh-120px)] justify-between">


### PR DESCRIPTION
## PR description :
- Summary:
  - Convert the `play` route to a server component to reduce client-side hydration and improve initial render performance.
  - Extract minimal client-side logic into a colocated `HeaderSectionClient` component that reads `useUser()` and renders `WelcomeHeader` and `BalanceCard`.
  - Keep existing interactive components (`PlayToday`, `JoinedContests`) unchanged and reused.

- Files added/changed:
  - Added: HeaderSectionClient.tsx — minimal client wrapper for user-context header.
  - Updated: page.tsx — converted to server component that composes `HeaderSectionClient`, `PlayToday`, and `JoinedContests`.
  - (Removed/cleaned up temporary artifacts created during refactor.)

- Motivation:
  - Reduce unnecessary client-side components and hydration.
  - Improve server-rendered shell and time-to-interactive for the Play page.
  - Keep client logic minimal and colocated for clarity and faster rendering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Header on the Play page now updates the welcome message and balance in real time on the client.
- Bug Fixes
  - Displays safe defaults when user data is unavailable, preventing blank or broken header states.
- Refactor
  - Moved the Play page header to a client-rendered section for improved responsiveness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->