### PR TITLE
feat(dashboard): stabilize handlers in InviteFriendsProvider & RecentQuizProvider

### DIFF
--- a/src/app/dashboard/InviteFriendsProvider.tsx
+++ b/src/app/dashboard/InviteFriendsProvider.tsx
@@ -1,33 +1,42 @@
 "use client";
 
+import React, { useCallback } from "react";
 import InviteFriendsBanner from "@/components/dashboard/InviteFriendsBanner";
 
 interface InviteFriendsProviderProps {
+  /** Called when user clicks the invite action */
   onInvite?: () => void;
+  /** Called when user dismisses the banner */
   onDismiss?: () => void;
 }
 
+/**
+ * Lightweight provider that wires optional callbacks to the InviteFriendsBanner.
+ * Handlers are memoized to avoid unnecessary re-renders of the banner.
+ */
 export default function InviteFriendsProvider({
   onInvite,
   onDismiss,
 }: InviteFriendsProviderProps) {
-  const handleInvite = () => {
-    if (onInvite) {
+  // Stable invite handler — calls provided callback or fallback analytics
+  const handleInvite = useCallback(() => {
+    if (typeof onInvite === "function") {
       onInvite();
-    } else {
-      // Default analytics tracking for invite action
-      console.log("User clicked invite friends");
+      return;
     }
-  };
+    // Fallback instrumentation (keep side-effect minimal here)
+    // Replace with real analytics call when available
+    console.log("InviteFriends: default invite action triggered");
+  }, [onInvite]);
 
-  const handleDismiss = () => {
-    if (onDismiss) {
+  // Stable dismiss handler — calls provided callback or fallback analytics
+  const handleDismiss = useCallback(() => {
+    if (typeof onDismiss === "function") {
       onDismiss();
-    } else {
-      // Default analytics tracking for banner dismiss
-      console.log("User dismissed invite banner");
+      return;
     }
-  };
+    console.log("InviteFriends: banner dismissed (default)");
+  }, [onDismiss]);
 
   return (
     <InviteFriendsBanner onInvite={handleInvite} onDismiss={handleDismiss} />

--- a/src/app/dashboard/RecentQuizProvider.tsx
+++ b/src/app/dashboard/RecentQuizProvider.tsx
@@ -1,39 +1,43 @@
 "use client";
 
+import React, { useCallback, useEffect, useState } from "react";
 import RecentQuizWidget from "@/components/dashboard/RecentQuizWidget";
 import { mockRecentQuiz, type RecentQuiz } from "@/lib/data/mockData";
-import { useEffect, useState } from "react";
 
 interface RecentQuizProviderProps {
+  /** Optional handler when a recent quiz is clicked */
   onQuizClick?: (quizId: string) => void;
 }
 
+/**
+ * Provides RecentQuizWidget with the latest quiz for the user.
+ * Uses mock data here; replace data-loading with real API call when available.
+ */
 export default function RecentQuizProvider({
   onQuizClick,
 }: RecentQuizProviderProps) {
   const [recentQuiz, setRecentQuiz] = useState<RecentQuiz | null>(null);
 
+  // Load mock data once. Keep timeout small to simulate async fetch.
   useEffect(() => {
-    // Simulate loading user data
-    const timer = setTimeout(() => {
-      setRecentQuiz(mockRecentQuiz);
-    }, 100);
-
+    const timer = setTimeout(() => setRecentQuiz(mockRecentQuiz), 100);
     return () => clearTimeout(timer);
   }, []);
 
-  const handleQuizClick = () => {
-    if (recentQuiz && onQuizClick) {
-      onQuizClick(recentQuiz.id);
-    } else if (recentQuiz) {
-      // Default behavior if no custom handler provided
-      console.log(`Navigate to quiz ${recentQuiz.id}`);
-    }
-  };
+  // Stable click handler to avoid changing identity on parent re-renders.
+  const handleQuizClick = useCallback(() => {
+    if (!recentQuiz) return;
 
-  if (!recentQuiz) {
-    return null;
-  }
+    if (typeof onQuizClick === "function") {
+      onQuizClick(recentQuiz.id);
+      return;
+    }
+
+    // Default behavior: log navigation intent. Replace with router push as needed.
+    console.log(`Navigate to quiz ${recentQuiz.id}`);
+  }, [recentQuiz, onQuizClick]);
+
+  if (!recentQuiz) return null;
 
   return (
     <RecentQuizWidget


### PR DESCRIPTION


## PR description 
Summary
- Memoize and stabilize click handlers in two dashboard provider components to avoid unnecessary re-renders and make callback wiring robust:
  - InviteFriendsProvider.tsx
  - RecentQuizProvider.tsx

What changed
- Added `useCallback` and a small React import where required to memoize handlers.
- Added lightweight JSDoc comments and safe type checks (e.g., `typeof onX === 'function'`) before invoking callbacks.
- Simplified mock-data loading effect in `RecentQuizProvider` while preserving behavior.
- Removed redundant ESLint disable comments.

Motivation
- Prevents handler identity changes on parent re-renders, reducing child re-renders and improving performance.
- Makes the intent and fallbacks explicit (safer default behavior).
- Prepares providers for easy extension (analytics, router navigation) without changing handler identity.

Files changed
- InviteFriendsProvider.tsx — memoized invite/dismiss handlers; added docs
- RecentQuizProvider.tsx — memoized quiz click handler; simplified mock-loading



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Improved dashboard responsiveness by stabilizing click handlers for Invite Friends and Recent Quiz, reducing unnecessary re-renders.
  - Streamlined recent quiz loading for a smoother initial experience; the widget appears only when data is ready.
- Documentation
  - Added clearer component and prop descriptions for dashboard providers to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->