### PR TITLE
feat: add play page and implement quiz components for joined and not joined quizzes

### DIFF
--- a/src/app/(general)/home/page.tsx
+++ b/src/app/(general)/home/page.tsx
@@ -1,10 +1,9 @@
-import { GeneralLayout } from "@/components/layout/GeneralLayout";
 import { HomePageContainer } from "@/components/pages/home/HomePageContainer";
 
 export default function Home() {
   return (
-    <GeneralLayout>
+    <>
       <HomePageContainer />
-    </GeneralLayout>
+    </>
   );
 }

--- a/src/app/(general)/play/page.tsx
+++ b/src/app/(general)/play/page.tsx
@@ -1,10 +1,9 @@
-import { GeneralLayout } from "@/components/layout/GeneralLayout";
 import { PlayPageContainer } from "@/components/pages/play/PlayPageContainer";
 
 export default function Play() {
   return (
-    <GeneralLayout>
+    <>
       <PlayPageContainer />
-    </GeneralLayout>
+    </>
   );
 }

--- a/src/app/(general)/play/page.tsx
+++ b/src/app/(general)/play/page.tsx
@@ -1,11 +1,10 @@
 import { GeneralLayout } from "@/components/layout/GeneralLayout";
 import { PlayPageContainer } from "@/components/pages/play/PlayPageContainer";
 
-
 export default function Play() {
   return (
     <GeneralLayout>
-        <PlayPageContainer/>
+      <PlayPageContainer />
     </GeneralLayout>
   );
 }

--- a/src/app/(general)/play/page.tsx
+++ b/src/app/(general)/play/page.tsx
@@ -1,0 +1,11 @@
+import { GeneralLayout } from "@/components/layout/GeneralLayout";
+import { PlayPageContainer } from "@/components/pages/play/PlayPageContainer";
+
+
+export default function Play() {
+  return (
+    <GeneralLayout>
+        <PlayPageContainer/>
+    </GeneralLayout>
+  );
+}

--- a/src/app/(general)/search/page.tsx
+++ b/src/app/(general)/search/page.tsx
@@ -1,10 +1,9 @@
-import { GeneralLayout } from "@/components/layout/GeneralLayout";
 import { SearchPageContainer } from "@/components/pages/search/SearchPageContainer";
 
 export default function Home() {
   return (
-    <GeneralLayout>
+    <>
       <SearchPageContainer />
-    </GeneralLayout>
+    </>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,8 +3,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-
-
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -45,7 +43,6 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
-
 :root {
   /* Core color tokens (kept) */
   --background: hsl(0 0% 99.2157%);
@@ -80,8 +77,6 @@
   --sidebar-accent-foreground: hsl(0 0% 0%);
   --sidebar-border: hsl(0 0% 92.1569%);
   --sidebar-ring: hsl(0 0% 0%);
-
-
 }
 
 .dark {
@@ -120,13 +115,21 @@
   --sidebar-ring: hsl(257.6687 100% 68.0392%);
 }
 
-  
-
 @layer base {
   * {
     @apply border-border outline-ring/50;
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  .scrollbar-hide {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { GeneralLayout } from "@/components/layout/GeneralLayout";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <GeneralLayout>{children}</GeneralLayout>
       </body>
     </html>
   );

--- a/src/components/models/quiz/QuizJoinedList.tsx
+++ b/src/components/models/quiz/QuizJoinedList.tsx
@@ -1,0 +1,35 @@
+import { QuizzesList } from "./QuizzesList";
+
+interface Quiz {
+  id: number;
+  quizName: string;
+  peopleJoined: number;
+  hoursLeftToStart: number;
+}
+
+const mockJoinedQuizzes: Quiz[] = [
+  {
+    id: 101,
+    quizName: "Weekly Crypto Quiz",
+    peopleJoined: 42,
+    hoursLeftToStart: 6,
+  },
+  {
+    id: 102,
+    quizName: "Solidity Basics",
+    peopleJoined: 28,
+    hoursLeftToStart: 3,
+  },
+  {
+    id: 103,
+    quizName: "Tokenomics Deep Dive",
+    peopleJoined: 16,
+    hoursLeftToStart: 48,
+  },
+];
+
+export function QuizJoinedList() {
+  return (
+    <QuizzesList title="Contests You have Joined" quizzes={mockJoinedQuizzes} />
+  );
+}

--- a/src/components/models/quiz/QuizNotJoinedTrendingCard.tsx
+++ b/src/components/models/quiz/QuizNotJoinedTrendingCard.tsx
@@ -1,0 +1,43 @@
+import { Progress } from "@/components/ui/progress";
+
+interface QuizNotJoinedTrendingCardProps {
+  quizName: string;
+  peopleJoined: number;
+  hoursLeftToStart: number;
+}
+
+export function QuizNotJoinedTrendingCard({
+  quizName,
+  peopleJoined,
+  hoursLeftToStart,
+}: QuizNotJoinedTrendingCardProps) {
+  // Calculate progress percentage (assuming max 24 hours)
+  const progressValue = Math.max(0, ((24 - hoursLeftToStart) / 24) * 100);
+
+  return (
+    <div className="relative flex-shrink-0 w-72 h-48 rounded-2xl overflow-hidden bg-[url('/images/playQuizImage.svg')] bg-cover bg-center border-2 border-primary">
+      {/* Dark overlay for better text readability */}
+      <div className="absolute inset-0 bg-foreground/60" />
+
+      {/* Content */}
+      <div className="relative h-full flex flex-col justify-between p-6 text-background">
+        {/* Quiz Name */}
+        <h3 className="text-xl font-bold leading-tight">{quizName}</h3>
+
+        {/* Bottom section with people joined and time left */}
+        <div className="space-y-3">
+          {/* People joined */}
+          <p className="text-sm font-medium">{peopleJoined} people joined</p>
+
+          {/* Hours left */}
+          <div className="space-y-2">
+            <p className="text-sm font-medium">{hoursLeftToStart} Hours Left</p>
+
+            {/* Progress bar */}
+            <Progress value={progressValue} className="w-full h-2 bg-muted" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/models/quiz/QuizNotJoinedTrendingCard.tsx
+++ b/src/components/models/quiz/QuizNotJoinedTrendingCard.tsx
@@ -11,8 +11,9 @@ export function QuizNotJoinedTrendingCard({
   peopleJoined,
   hoursLeftToStart,
 }: QuizNotJoinedTrendingCardProps) {
-  // Calculate progress percentage (assuming max 24 hours)
-  const progressValue = Math.max(0, ((24 - hoursLeftToStart) / 24) * 100);
+  // Calculate progress percentage (assuming max 24 hours) and clamp to [0,100]
+  const rawPercent = ((24 - hoursLeftToStart) / 24) * 100;
+  const progressValue = Math.min(100, Math.max(0, rawPercent));
 
   return (
     <div className="relative flex-shrink-0 w-72 h-48 rounded-2xl overflow-hidden bg-[url('/images/playQuizImage.svg')] bg-cover bg-center border-2 border-primary">

--- a/src/components/models/quiz/QuizNotJoinedTrendingList.tsx
+++ b/src/components/models/quiz/QuizNotJoinedTrendingList.tsx
@@ -1,0 +1,65 @@
+import { QuizNotJoinedTrendingCard } from "./QuizNotJoinedTrendingCard";
+
+interface Quiz {
+  id: number;
+  quizName: string;
+  peopleJoined: number;
+  hoursLeftToStart: number;
+}
+
+const mockNotJoinedQuizzes: Quiz[] = [
+  {
+    id: 201,
+    quizName: "Algorithmic Stablecoins",
+    peopleJoined: 20,
+    hoursLeftToStart: 18,
+  },
+  {
+    id: 202,
+    quizName: "Layer 2 Scaling",
+    peopleJoined: 278,
+    hoursLeftToStart: 8,
+  },
+  {
+    id: 203,
+    quizName: "Cross-Chain Mechanics",
+    peopleJoined: 199,
+    hoursLeftToStart: 2,
+  },
+  {
+    id: 204,
+    quizName: "NFT Valuation",
+    peopleJoined: 144,
+    hoursLeftToStart: 16,
+  },
+  {
+    id: 205,
+    quizName: "Advanced DeFi Strategies",
+    peopleJoined: 320,
+    hoursLeftToStart: 4,
+  },
+];
+
+export function QuizNotJoinedTrendingList() {
+  return (
+    <div className="mt-4">
+      <h3 className="mx-4 mb-4 text-lg font-semibold text-primary-foreground">
+        What would you like to play today?
+      </h3>
+
+      {/* Horizontal scrollable container */}
+      <div className="px-4">
+        <div className="flex gap-4 overflow-x-auto scrollbar-hide pb-4">
+          {mockNotJoinedQuizzes.map((quiz) => (
+            <QuizNotJoinedTrendingCard
+              key={quiz.id}
+              quizName={quiz.quizName}
+              peopleJoined={quiz.peopleJoined}
+              hoursLeftToStart={quiz.hoursLeftToStart}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/play/PlayPageContainer.tsx
+++ b/src/components/pages/play/PlayPageContainer.tsx
@@ -1,0 +1,11 @@
+import { QuizJoinedList } from "@/components/models/quiz/QuizJoinedList";
+import { QuizNotJoinedTrendingList } from "@/components/models/quiz/QuizNotJoinedTrendingList";
+
+export function PlayPageContainer() {
+  return (
+    <>
+      <QuizNotJoinedTrendingList />
+      <QuizJoinedList />
+    </>
+  );
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="bg-primary h-full w-full flex-1 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+}
+
+export { Progress }


### PR DESCRIPTION

## PR Description
Summary
- Add a horizontally-scrollable "not-joined trending" card list and a simple Joined list used by the home page.
- Replace the previous `QuizzesList` usage in the trending-not-joined area with a new, theme-aware card component that uses the existing background image and the project's UI Progress component.
- Use Tailwind theme tokens (no hardcoded colors, no inline styles or cn helpers). Keep rounded corners and a visible primary-colored border.

What  changed 
- Added: QuizNotJoinedTrendingCard.tsx
  - Card UI using playQuizImage.svg as background.
  - Shows `quizName`, `peopleJoined`, `hoursLeftToStart` and a progress bar (`@/components/ui/progress`).
  - Theme-aware overlay (`bg-foreground/60`), theme text classes, `rounded-2xl`, `border-2 border-primary`.
- Updated: QuizNotJoinedTrendingList.tsx
  - Removed `QuizzesList` usage and renders `QuizNotJoinedTrendingCard` items inside a horizontal, scrollable container.
  - Mock data used for now.
- Added/Updated: QuizJoinedList.tsx
  - Simple `QuizzesList` wrapper with mock joined quizzes (keeps parity with Trending list).
- Updated: globals.css
  - (earlier) added a small utility for hiding scrollbars (`.scrollbar-hide`) to keep the horizontal scroll clean.

Rationale / design decisions
- Theme tokens used instead of hardcoded colors so the UI follows your existing design system.
- No inline style objects, no cn() helper; all styling is via Tailwind classes.
- Card border is now `border-2 border-primary` to use the primary theme color and avoid the white-ish border.
- Kept mock arrays for now — this is a purely UI/layout change; data wiring will be handled separately.

<img width="419" height="859" alt="image" src="https://github.com/user-attachments/assets/55b8094c-eef4-4dd8-a9a9-dc061feac5a1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Play page showcasing quizzes.
  - Added a Trending section of quizzes you haven’t joined, with cards showing participants, hours left, and a progress indicator.
  - Added a Joined section listing quizzes you’re participating in.
  - Added a reusable progress UI component for consistent progress display.

- Style
  - Implemented horizontal, swipeable lists with hidden scrollbars for a cleaner look.

- Refactor
  - Updated global layout to wrap app content in a shared layout component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->